### PR TITLE
support relative url root at /data

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,25 @@
 
 require_relative 'config/environment'
 
-run Rails.application
+APP_ROOT = DeepBlueDocs::Application.config.relative_url_root || "/"
+
+map APP_ROOT do
+  run Rails.application
+end
+
+# Auto-redirect root URL hits to the app as a development convenience
+if "/" != APP_ROOT
+  map "/" do
+    run ->(env) do
+      req = Rack::Request.new(env)
+      res = Rack::Response.new
+      if req.path =~ /^\/*$/
+        res.redirect(APP_ROOT)
+      else
+        res.status = 404
+        res.write "The requested URL #{req.fullpath} was not found."
+      end
+      res.finish
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,6 +82,8 @@ module DeepBlueDocs
     config.derivative_max_file_size = 4_000_000_000 # set to -1 for no limit
     config.derivative_max_file_size_str = ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert(config.derivative_max_file_size, precision: 3 )
 
+    config.relative_url_root = '/data' unless Rails.env.test?
+
     # ingest virus scan config
     config.virus_scan_max_file_size = 4_000_000_000
     config.virus_scan_retry = true


### PR DESCRIPTION
copied from https://github.com/mlibrary/umrdr, especially
https://github.com/mlibrary/umrdr/blob/master/config.ru

I haven't verified that everything related to the relative URL root works (especially since there are no works deposited in that instance yet), but at least the front page loads.