### PR TITLE
BLUEDOC-349-ie-error2

### DIFF
--- a/app/helpers/deepblue_helper.rb
+++ b/app/helpers/deepblue_helper.rb
@@ -6,8 +6,13 @@ module DeepblueHelper
     ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert( value, precision: precision )
   end
 
-	def users_browser
-		user_agent =  request.env['HTTP_USER_AGENT'].downcase 
+  def user_agent()
+    user_agent =  request.env['HTTP_USER_AGENT']
+    user_agent
+  end
+
+	def users_browser()
+		user_agent = user_agent().downcase
 		@users_browser ||= begin
 		  if user_agent.index('msie') && !user_agent.index('opera') && !user_agent.index('webtv')
 		                # 'ie'+user_agent[user_agent.index('msie')+5].chr
@@ -34,6 +39,10 @@ module DeepblueHelper
 		        'msnbot'
 		    elsif user_agent.index('yahoo! slurp')
 		        'yahoobot'
+		    elsif user_agent.index('mozilla/5.0 (windows nt 6.3; win64, x64')
+		        'msie'
+		    elsif user_agent.index('mozilla/5.0 (windows nt 10.0; win64; x64)')
+		        'msie'  
 		    #Everything thinks it's mozilla, so this goes last
 		    elsif user_agent.index('mozilla/')
 		        'gecko'

--- a/app/views/_ie_announcement.html.erb
+++ b/app/views/_ie_announcement.html.erb
@@ -1,7 +1,8 @@
 <div class="announcement" style="color:red; background-color: white;">
-	  <div class="row">
-    	<div class="col-sm-10">
-					Warning: The Internet Explorer browser is likely to cause errors with DeepBlue Data.
+    <div class="row">
+      <div class="col-sm-10">
+					Warning: The Internet Explorer browser is likely to cause errors with DeepBlue Data. 
+					<!--<br />User agent is: <%= user_agent() %>; User browser is <%= users_browser() %>--> 
 					<br />
 			</div>
     </div>

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,7 +1,7 @@
 <header class="site-header">
   <nav id="masthead" class="navbar navbar-inverse navbar-static-top" role="navigation">
     <%= render '/masthead_announcement' %>
-    <%= render '/ie_announcement' if @users_browser ==  'msie' %>
+    <%= render '/ie_announcement' if  users_browser() == 'msie' %>
     <div class="container">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="col-sm-6">


### PR DESCRIPTION
Updated to handle edge and ie 10.
Have to use request.env['HTTP_USER_AGENT']. Ugh.

Code:
`module DeepblueHelper

  def self.human_readable_size( value, precision: 3 )
    ActiveSupport::NumberHelper::NumberToHumanSizeConverter.convert( value, precision: precision )
  end

  def user_agent()
    user_agent =  request.env['HTTP_USER_AGENT']
    user_agent
  end

	def users_browser()
		user_agent = user_agent().downcase
		@users_browser ||= begin
		  if user_agent.index('msie') && !user_agent.index('opera') && !user_agent.index('webtv')
		                # 'ie'+user_agent[user_agent.index('msie')+5].chr
		                'msie'
		    elsif user_agent.index('gecko/')
		        'gecko'
		    elsif user_agent.index('opera')
		        'opera'
		    elsif user_agent.index('konqueror')
		        'konqueror'
		    elsif user_agent.index('ipod')
		        'ipod'
		    elsif user_agent.index('ipad')
		        'ipad'
		    elsif user_agent.index('iphone')
		        'iphone'
		    elsif user_agent.index('chrome/')
		        'chrome'
		    elsif user_agent.index('applewebkit/')
		        'safari'
		    elsif user_agent.index('googlebot/')
		        'googlebot'
		    elsif user_agent.index('msnbot')
		        'msnbot'
		    elsif user_agent.index('yahoo! slurp')
		        'yahoobot'
		    elsif user_agent.index('mozilla/5.0 (windows nt 6.3; win64, x64')
		        'msie'
		    elsif user_agent.index('mozilla/5.0 (windows nt 10.0; win64; x64)')
		        'msie'  #Everything thinks it's mozilla, so this goes last
		    elsif user_agent.index('mozilla/')
		        'gecko'
		    else
		        'unknown'
		    end
		    end

		    return @users_browser
	end

end`