### PR TITLE
BLUEDOC-389 - Some files failing to upload in bulk upload 3

### DIFF
--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -22,14 +22,20 @@ module Hyrax
       # @param [Hyrax::UploadedFile, File] file the file uploaded by the user
       # @param [Symbol, #to_s] relation
       # @return [IngestJob, FalseClass] false on failure, otherwise the queued job
-      def create_content( file, relation = :original_file, from_url: false, continue_job_chain_later: true )
+      def create_content( file,
+                          relation = :original_file,
+                          from_url: false,
+                          continue_job_chain_later: true,
+                          uploaded_file_ids: [] )
         Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
                                              Deepblue::LoggingHelper.called_from,
                                              "file=#{file}",
                                              Deepblue::LoggingHelper.obj_to_json( "file", file ),
                                              "relation=#{relation}",
                                              "from_url=#{from_url}",
-                                             "continue_job_chain_later=#{continue_job_chain_later}" ]
+                                             "continue_job_chain_later=#{continue_job_chain_later}",
+                                             "uploaded_file_ids=#{uploaded_file_ids}",
+                                              "" ]
         # If the file set doesn't have a title or label assigned, set a default.
         file_set.label ||= label_for(file)
         file_set.title = [file_set.label] if file_set.title.blank?
@@ -52,7 +58,9 @@ module Hyrax
             InheritPermissionsJob.perform_now( parent )
           end
         else
-          IngestJob.perform_now( io_wrapper, continue_job_chain_later: continue_job_chain_later )
+          IngestJob.perform_now( io_wrapper,
+                                 continue_job_chain_later: continue_job_chain_later,
+                                 uploaded_file_ids: uploaded_file_ids )
         end
       end
 

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -11,7 +11,8 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
                filepath = nil,
                continue_job_chain: true,
                continue_job_chain_later: true,
-               delete_input_file: true )
+               delete_input_file: true,
+               uploaded_file_ids: [] )
 
     Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
                                          Deepblue::LoggingHelper.called_from,
@@ -21,13 +22,15 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
                                          "continue_job_chain=#{continue_job_chain}",
                                          "continue_job_chain_later=#{continue_job_chain_later}",
                                          "delete_input_file=#{delete_input_file}",
+                                         "uploaded_file_ids=#{uploaded_file_ids}",
                                          "" ]
     Deepblue::IngestHelper.characterize( file_set,
                                          repository_file_id,
                                          filepath,
                                          continue_job_chain: continue_job_chain,
                                          continue_job_chain_later: continue_job_chain_later,
-                                         delete_input_file: delete_input_file )
+                                         delete_input_file: delete_input_file,
+                                         uploaded_file_ids: uploaded_file_ids )
   rescue Exception => e # rubocop:disable Lint/RescueException
     Rails.logger.error "CharacterizeJob.perform(#{file_set},#{repository_file_id},#{filepath}) #{e.class}: #{e.message}"
   end

--- a/app/jobs/ingest_job.rb
+++ b/app/jobs/ingest_job.rb
@@ -20,7 +20,8 @@ class IngestJob < ::Hyrax::ApplicationJob
                notification: false,
                continue_job_chain: true,
                continue_job_chain_later: true,
-               delete_input_file: true )
+               delete_input_file: true,
+               uploaded_file_ids: [] )
 
     uploaded_file = wrapper.uploaded_file
     Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
@@ -38,10 +39,12 @@ class IngestJob < ::Hyrax::ApplicationJob
                                            # Deepblue::LoggingHelper.obj_attribute_names( "uploaded_file", uploaded_file ),
                                            Deepblue::LoggingHelper.obj_to_json( "uploaded_file", uploaded_file ),
                                            "uploaded_file.id=#{Deepblue::UploadHelper.uploaded_file_id( uploaded_file )}",
+                                           "uploaded_file_ids=#{uploaded_file_ids}",
                                            "" ]
     wrapper.ingest_file( continue_job_chain: continue_job_chain,
                          continue_job_chain_later: continue_job_chain_later,
-                         delete_input_file: delete_input_file )
+                         delete_input_file: delete_input_file,
+                         uploaded_file_ids: uploaded_file_ids )
   end
 
 end

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -73,18 +73,22 @@ class JobIoWrapper < ApplicationRecord
 
   def ingest_file( continue_job_chain: true,
                    continue_job_chain_later: true,
-                   delete_input_file: true )
+                   delete_input_file: true,
+                   uploaded_file_ids: [] )
     actor = file_actor
     Deepblue::LoggingHelper.bold_debug [ "#{caller_locations(1, 1)[0]}",
                                          "actor.class=#{actor.class.name}",
                                          "relation=#{relation}",
                                          "continue_job_chain=#{continue_job_chain}",
                                          "continue_job_chain_later=#{continue_job_chain_later}",
-                                         "delete_input_file=#{delete_input_file}" ]
+                                         "delete_input_file=#{delete_input_file}",
+                                         "uploaded_file_ids=#{uploaded_file_ids}",
+                                         "" ]
     actor.ingest_file(self,
                       continue_job_chain: continue_job_chain,
                       continue_job_chain_later: continue_job_chain_later,
-                      delete_input_file: delete_input_file )
+                      delete_input_file: delete_input_file,
+                      uploaded_file_ids: uploaded_file_ids )
   end
 
   private

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -231,6 +231,7 @@ Hyrax.config do |config|
 
   # ActiveJob queue to handle ingest-like jobs
   # config.ingest_queue_name = :default
+  config.ingest_queue_name = :ingest
 
   ## Attributes for the lock manager which ensures a single process/thread is mutating a ore:Aggregation at once.
   # How many times to retry to acquire the lock before raising UnableToAcquireLockError


### PR DESCRIPTION
* Changed the ingest-like jobs to use "ingest" queue.
* Added starting attach to work upload log and finished.
* Added (and passed around but did not use) a list of ids of the uploaded_files to ingest jobs