### PR TITLE
BLUEDOC-389 - Some files failing to upload in bulk upload 4

### DIFF
--- a/app/controllers/hyrax/uploads_controller.rb
+++ b/app/controllers/hyrax/uploads_controller.rb
@@ -49,6 +49,12 @@ module Hyrax
                                   user: current_user.to_s )
     rescue Exception => e # rubocop:disable Lint/RescueException
       Rails.logger.error "UploadsController.create #{e.class}: #{e.message} at #{e.backtrace[0]}"
+      Deepblue::UploadHelper.log( class_name: self.class.name,
+                                  event: "create",
+                                  event_note: "failed",
+                                  id: "NA",
+                                  exception: e.to_s,
+                                  backtrace0: e.backtrace[0..4] )
       raise
     end
 
@@ -68,6 +74,15 @@ module Hyrax
                                   user: current_user.to_s )
       @upload.destroy
       head :no_content
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      Rails.logger.error "UploadsController.destroy #{e.class}: #{e.message} at #{e.backtrace[0]}"
+      Deepblue::UploadHelper.log( class_name: self.class.name,
+                                  event: "destroy",
+                                  event_note: "failed",
+                                  id: "NA",
+                                  exception: e.to_s,
+                                  backtrace0: e.backtrace[0] )
+      raise
     end
 
   end

--- a/app/models/concerns/deepblue/file_set_metadata.rb
+++ b/app/models/concerns/deepblue/file_set_metadata.rb
@@ -26,7 +26,8 @@ module Deepblue
         index.as :stored_searchable
       end
 
-      property :file_size, predicate: ::RDF::Vocab::DC.SizeOrDuration, multiple: false
+      # property :file_size, predicate: ::RDF::Vocab::DC.SizeOrDuration, multiple: false
+      property :file_size, predicate: ::RDF::Vocab::DC.SizeOrDuration, multiple: true
 
       property :prior_identifier, predicate: ActiveFedora::RDF::Fcrepo::Model.altIds, multiple: true do |index|
         index.as :stored_searchable


### PR DESCRIPTION
* Added more logging, including tracking of the uploaded_file.id
* Added some more error trapping to attach files to work
* Changed the definition of file_size metadata from singular to multiple (was causing an exception that was being eaten until I added the above noted error trapping)