### PR TITLE
BLUEDOC-396 - ScholarsArchive references throws errors

### DIFF
--- a/app/forms/deepbluedocs/default_work_form_behavior.rb
+++ b/app/forms/deepbluedocs/default_work_form_behavior.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module Deepbluedocs
+
   module DefaultWorkFormBehavior
     extend ActiveSupport::Concern
     included do
@@ -170,4 +173,5 @@ module Deepbluedocs
       end
     end
   end
+
 end

--- a/app/forms/deepbluedocs/dissertation_work_form_behavior.rb
+++ b/app/forms/deepbluedocs/dissertation_work_form_behavior.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module Deepbluedocs
+
   module DissertationWorkFormBehavior
     extend ActiveSupport::Concern
     included do
-      #include ScholarsArchive::DateTermsBehavior
-      #include ScholarsArchive::NestedBehavior
+      # include ScholarsArchive::DateTermsBehavior
+      # include ScholarsArchive::NestedBehavior
 
       # accessor attributes only used to group dates and geo fields and allow proper ordering in this form
       attr_accessor :dates_section
@@ -62,4 +65,5 @@ module Deepbluedocs
       end
     end
   end
+
 end

--- a/app/forms/deepbluedocs/generic_work_form_behavior.rb
+++ b/app/forms/deepbluedocs/generic_work_form_behavior.rb
@@ -1,9 +1,12 @@
+# frozen_string_literal: true
+
 module Deepbluedocs
+
   module GenericWorkFormBehavior
     extend ActiveSupport::Concern
     included do
-      #include ScholarsArchive::DateTermsBehavior
-      #include ScholarsArchive::NestedBehavior
+      # include ScholarsArchive::DateTermsBehavior
+      # include ScholarsArchive::NestedBehavior
 
       # accessor attributes only used to group dates and geo fields and allow proper ordering in this form
       attr_accessor :dates_section
@@ -64,4 +67,5 @@ module Deepbluedocs
       end
     end
   end
+
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -26,7 +26,8 @@ class SolrDocument
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
 
-  # use_extension(ScholarsArchive::Document::QualifiedDublinCore)
+  # This fails to load.
+  # use_extension(::ScholarsArchive::Document::QualifiedDublinCore)
 
   # Do content negotiation for AF models.
 
@@ -41,7 +42,9 @@ class SolrDocument
   end
 
   def academic_affiliation_label
-    ScholarsArchive::LabelParserService.parse_label_uris(self['academic_affiliation_label_ssim'])
+    # references to ScholarsArchive raise ActionView::Template::Error (uninitialized constant SolrDocument::ScholarsArchive)
+    # ScholarsArchive::LabelParserService.parse_label_uris(self['academic_affiliation_label_ssim'])
+    self['academic_affiliation_label_ssim']
   end
 
   def curation_notes_admin_label
@@ -53,11 +56,15 @@ class SolrDocument
   end
 
   def degree_field_label
-    ScholarsArchive::LabelParserService.parse_label_uris(self['degree_field_label_ssim'])
+    # references to ScholarsArchive raise ActionView::Template::Error (uninitialized constant SolrDocument::ScholarsArchive)
+    # ScholarsArchive::LabelParserService.parse_label_uris(self['degree_field_label_ssim'])
+    self['degree_field_label_ssim']
   end
 
   def degree_grantors_label
-    ScholarsArchive::LabelParserService.parse_label_uris(self['degree_grantors_label_ssim'])
+    # references to ScholarsArchive raise ActionView::Template::Error (uninitialized constant SolrDocument::ScholarsArchive)
+    # ScholarsArchive::LabelParserService.parse_label_uris(self['degree_grantors_label_ssim'])
+    self['degree_grantors_label_ssim']
   end
 
   def doi_label
@@ -97,11 +104,15 @@ class SolrDocument
   end
 
   def nested_related_items_label
-    ScholarsArchive::LabelParserService.parse_label_uris(self[Solrizer.solr_name('nested_related_items_label', :symbol)]) || []
+    # references to ScholarsArchive raise ActionView::Template::Error (uninitialized constant SolrDocument::ScholarsArchive)
+    # ScholarsArchive::LabelParserService.parse_label_uris(self[Solrizer.solr_name('nested_related_items_label', :symbol)]) || []
+    self[Solrizer.solr_name('nested_related_items_label', :symbol)] || []
   end
 
   def other_affiliation_label
-    ScholarsArchive::LabelParserService.parse_label_uris(self['other_affiliation_label_ssim'])
+    # references to ScholarsArchive raise ActionView::Template::Error (uninitialized constant SolrDocument::ScholarsArchive)
+    # ScholarsArchive::LabelParserService.parse_label_uris(self['other_affiliation_label_ssim'])
+    self['other_affiliation_label_ssim']
   end
 
   def peerreviewed_label


### PR DESCRIPTION
* References to ScholarsArchive have been removed.
* These references have been causing occasional errors to appear in the logs.