### PR TITLE
BLUEDOC-414 - File details page displays wrong user for file upload

### DIFF
--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Hyrax
+
+  module Actors
+
+    # Creates a work and attaches files to the work
+    class CreateWithFilesActor < Hyrax::Actors::AbstractActor
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.create(env) && attach_files(files, env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
+        files = uploaded_files(uploaded_file_ids)
+        validate_files(files, env) && next_actor.update(env) && attach_files(files, env)
+      end
+
+      private
+
+        def filter_file_ids(input)
+          Array.wrap(input).select(&:present?)
+        end
+
+        # ensure that the files we are given are owned by the depositor of the work
+        def validate_files(files, env)
+          expected_user_id = env.user.id
+          files.each do |file|
+            if file.user_id != expected_user_id
+              Rails.logger.error "User #{env.user.user_key} attempted to ingest uploaded_file #{file.id}, but it belongs to a different user"
+              return false
+            end
+          end
+          true
+        end
+
+        # @return [TrueClass]
+        def attach_files(files, env)
+          return true if files.blank?
+          AttachFilesToWorkJob.perform_later( env.curation_concern, files, env.user.user_key, env.attributes.to_h.symbolize_keys )
+          true
+        end
+
+        # Fetch uploaded_files from the database
+        def uploaded_files(uploaded_file_ids)
+          return [] if uploaded_file_ids.empty?
+          UploadedFile.find(uploaded_file_ids)
+        end
+
+    end
+
+  end
+
+end

--- a/app/helpers/deepblue/ingest_helper.rb
+++ b/app/helpers/deepblue/ingest_helper.rb
@@ -286,10 +286,16 @@ module Deepblue
           CreateDerivativesJob.perform_later( file_set,
                                               repository_file_id,
                                               file_name,
-                                              delete_input_file,
+                                              current_user: current_user,
+                                              delete_input_file: delete_input_file,
                                               uploaded_file_ids: uploaded_file_ids )
         else
-          # CreateDerivativesJob.perform_now( file_set, repository_file_id, file_name, delete_input_file )
+          # CreateDerivativesJob.perform_now( file_set,
+          #                                   repository_file_id,
+          #                                   file_name,
+          #                                   current_user: current_user,
+          #                                   delete_input_file: delete_input_file,
+          #                                   uploaded_file_ids: uploaded_file_ids )
           create_derivatives( file_set,
                               repository_file_id,
                               file_name,

--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -9,16 +9,18 @@ class AttachFilesToWorkJob < ::Hyrax::ApplicationJob
 
   # @param [ActiveFedora::Base] work - the work object
   # @param [Array<Hyrax::UploadedFile>] uploaded_files - an array of files to attach
-  def perform( work, uploaded_files, **work_attributes )
+  def perform( work, uploaded_files, user_key, **work_attributes )
     @processed = []
     Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
                                          Deepblue::LoggingHelper.called_from,
                                          "work=#{work}",
+                                         "user_key=#{user_key}",
                                          "uploaded_files=#{uploaded_files}",
                                          "uploaded_files.count=#{uploaded_files.count}",
                                          "work_attributes=#{work_attributes}" ] if ATTACH_FILES_TO_WORK_JOB_IS_VERBOSE
     depositor = proxy_or_depositor( work )
-    user = User.find_by_user_key( depositor )
+    # user = User.find_by_user_key( depositor ) # Wrong!, it's actually on the upload file record.
+    user = User.find_by_user_key( user_key )
     uploaded_file_ids = uploaded_files.map { |u| u.id }
     Deepblue::UploadHelper.log( class_name: self.class.name,
                                 event: "attach_files_to_work",
@@ -110,7 +112,7 @@ class AttachFilesToWorkJob < ::Hyrax::ApplicationJob
                                            "uploaded_file.file_set_uri=#{uploaded_file.file_set_uri}",
                                            # Deepblue::LoggingHelper.obj_methods( "uploaded_file", uploaded_file ),
                                            # Deepblue::LoggingHelper.obj_instance_variables( "uploaded_file", uploaded_file ),
-                                           # Deepblue::LoggingHelper.obj_attribute_names( "uploaded_file", uploaded_file ),
+                                           Deepblue::LoggingHelper.obj_attribute_names( "uploaded_file", uploaded_file ),
                                            Deepblue::LoggingHelper.obj_to_json( "uploaded_file", uploaded_file ),
                                            "uploaded_file.id=#{Deepblue::UploadHelper.uploaded_file_id( uploaded_file )}",
                                            "user=#{user}",

--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -11,6 +11,7 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
                filepath = nil,
                continue_job_chain: true,
                continue_job_chain_later: true,
+               current_user: nil,
                delete_input_file: true,
                uploaded_file_ids: [] )
 
@@ -21,6 +22,7 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
                                          "filepath=#{filepath}",
                                          "continue_job_chain=#{continue_job_chain}",
                                          "continue_job_chain_later=#{continue_job_chain_later}",
+                                         "current_user=#{current_user}",
                                          "delete_input_file=#{delete_input_file}",
                                          "uploaded_file_ids=#{uploaded_file_ids}",
                                          "" ]
@@ -29,6 +31,7 @@ class CharacterizeJob < ::Hyrax::ApplicationJob
                                          filepath,
                                          continue_job_chain: continue_job_chain,
                                          continue_job_chain_later: continue_job_chain_later,
+                                         current_user: current_user,
                                          delete_input_file: delete_input_file,
                                          uploaded_file_ids: uploaded_file_ids )
   rescue Exception => e # rubocop:disable Lint/RescueException

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -6,8 +6,20 @@ class CreateDerivativesJob < ::Hyrax::ApplicationJob
   # @param [FileSet] file_set
   # @param [String] repository_file_id identifier for a Hydra::PCDM::File
   # @param [String, NilClass] filepath the cached file within the Hyrax.config.working_path
-  def perform( file_set, repository_file_id, filepath = nil, delete_input_file = true )
-    Deepblue::IngestHelper.create_derivatives( file_set, repository_file_id, filepath, delete_input_file: delete_input_file )
+  def perform( file_set,
+               repository_file_id,
+               filepath = nil,
+               current_user: nil,
+               delete_input_file: true,
+               uploaded_file_ids: [] )
+
+    Deepblue::IngestHelper.create_derivatives( file_set,
+                                               repository_file_id,
+                                               filepath,
+                                               current_user: current_user,
+                                               delete_input_file: delete_input_file,
+                                               uploaded_file_ids: uploaded_file_ids )
+
   rescue Exception => e # rubocop:disable Lint/RescueException
     Rails.logger.error "CreateDerivativesJob.perform(#{file_set},#{repository_file_id},#{filepath}) #{e.class}: #{e.message}"
   end

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -75,6 +75,7 @@ class JobIoWrapper < ApplicationRecord
                    continue_job_chain_later: true,
                    delete_input_file: true,
                    uploaded_file_ids: [] )
+
     actor = file_actor
     Deepblue::LoggingHelper.bold_debug [ "#{caller_locations(1, 1)[0]}",
                                          "actor.class=#{actor.class.name}",
@@ -84,9 +85,16 @@ class JobIoWrapper < ApplicationRecord
                                          "delete_input_file=#{delete_input_file}",
                                          "uploaded_file_ids=#{uploaded_file_ids}",
                                          "" ]
+
+    user_key = nil
+    unless user_id.nil?
+      user = User.find user_id
+      user_key = user.user_key
+    end
     actor.ingest_file(self,
                       continue_job_chain: continue_job_chain,
                       continue_job_chain_later: continue_job_chain_later,
+                      current_user: user_key,
                       delete_input_file: delete_input_file,
                       uploaded_file_ids: uploaded_file_ids )
   end

--- a/lib/hydra/works/services/add_file_to_file_set.rb
+++ b/lib/hydra/works/services/add_file_to_file_set.rb
@@ -18,10 +18,25 @@ module Hydra::Works
     # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
     def self.call( file_set, file, type, update_existing: true, versioning: true )
       monkey_call( file_set, file, type, update_existing: update_existing, versioning: versioning )
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "file=#{file}",
+                                             ::Deepblue::LoggingHelper.obj_class( "file", file ) ]
+      if file.respond_to? :user_id
+        ingester = User.find file.user_id
+        ingester = ingester.user_key
+      elsif file.respond_to? :current_user
+        ingester = file.current_user
+      else
+        ingester = Deepblue::ProvenanceHelper.system_as_current_user if ingester.nil?
+      end
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "ingester=#{ingester}" ]
       file_set.provenance_ingest( current_user: Deepblue::ProvenanceHelper.system_as_current_user,
                                   calling_class: 'Hydra::Works::AddFileToFileSet',
                                   ingest_id: '',
-                                  ingester: Deepblue::ProvenanceHelper.system_as_current_user,
+                                  ingester: ingester,
                                   ingest_timestamp: nil )
       begin
         file_set.virus_scan
@@ -32,4 +47,5 @@ module Hydra::Works
     end
 
   end
+
 end

--- a/lib/hydra/works/services/upload_file_to_file_set.rb
+++ b/lib/hydra/works/services/upload_file_to_file_set.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Hydra::Works
+
+  class UploadFileToFileSet
+    # Sets a file as the primary file (original_file) of the file_set
+    # @param [Hydra::PCDM::FileSet] file_set the file will be added to
+    # @param [IO,File,Rack::Multipart::UploadedFile, #read] object that will be the contents. If file responds to :mime_type or :original_name, those will be called to provide technical metadata.
+    # @param [Array] additional_services (ie Generating Thumbnails) to call with file_set after adding the file as its original_file
+    # @param [Boolean] update_existing whether to update an existing file if there is one. When set to true, performs a create_or_update. When set to false, always creates a new file within file_set.files.
+    # @param [Boolean] versioning whether to create new version entries (only applicable if +type+ corresponds to a versionable file)
+
+    def self.call(file_set, file, additional_services: [], update_existing: true, versioning: true)
+
+      Hydra::Works::AddFileToFileSet.call(file_set, file, :original_file, update_existing: update_existing, versioning: versioning)
+
+      # Call any additional services
+      additional_services.each do |service|
+        ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                               ::Deepblue::LoggingHelper.called_from,
+                                               ::Deepblue::LoggingHelper.obj_class( "service", service ) ]
+        service.call(file_set)
+      end
+
+      file_set.save
+      file_set
+    end
+
+  end
+
+end

--- a/lib/tasks/new_content_service.rb
+++ b/lib/tasks/new_content_service.rb
@@ -492,7 +492,12 @@ module Deepblue
         # puts "id=#{id} path=#{path} filename=#{filename} file_ids=#{file_ids}"
         log_msg( "#{mode}: building file #{file_set_of} of #{file_set_count}#{file_size}" ) if @verbose
         fname = filename || File.basename( path )
-        file_set = build_file_set_new( id: id, depositor: work.depositor, path: path, original_name: fname, build_mode: mode )
+        file_set = build_file_set_new( id: id,
+                                       depositor: work.depositor,
+                                       path: path,
+                                       original_name: fname,
+                                       build_mode: mode,
+                                       current_user: user_key )
         file_set.title = Array( fname )
         file_set.label = fname
         now = DateTime.now.new_offset( 0 )
@@ -503,7 +508,11 @@ module Deepblue
         file_set.prior_identifier = file_ids if file_ids.present?
         file_set.save!
         # TODO: move ingest step to after attach to work, this will probably fix file_sets that turn up with missing file sizes
-        return build_file_set_ingest( file_set: file_set, path: path, checksum_algorithm: nil, checksum_value: nil, build_mode: mode )
+        return build_file_set_ingest( file_set: file_set,
+                                      path: path,
+                                      checksum_algorithm: nil,
+                                      checksum_value: nil,
+                                      build_mode: mode )
       end
 
       def build_file_set_from_hash( id:,
@@ -533,7 +542,8 @@ module Deepblue
                                        depositor: depositor,
                                        path: path,
                                        original_name: original_name,
-                                       build_mode: build_mode )
+                                       build_mode: build_mode,
+                                       current_user: user_key )
 
         curation_notes_admin = Array( file_set_hash[:curation_notes_admin] )
         curation_notes_user = Array( file_set_hash[:curation_notes_user] )
@@ -618,28 +628,20 @@ module Deepblue
         return file_set
       end
 
-      def build_file_set_new( id:, depositor:, path:, original_name:, build_mode: )
+      def build_file_set_new( id:, depositor:, path:, original_name:, build_mode:, current_user: )
         log_msg( "#{build_mode}: processing: #{path}" )
         file = File.open( path )
         # fix so that filename comes from the name of the file and not the hash
         file.define_singleton_method( :original_name ) do
           original_name
         end
+        file.define_singleton_method( :current_user ) do
+          current_user
+        end
         id_new = MODE_MIGRATE == build_mode ? id : nil
         file_set = new_file_set( id: id_new )
         file_set.apply_depositor_metadata( depositor )
         upload_file_to_file_set( file_set, file )
-        # attempts = 0
-        # file_set = nil
-        # loop do
-        #   break if attempts > 6
-        #   file_set = new_file_set( id: id_new )
-        #   file_set.apply_depositor_metadata( depositor )
-        #   success = upload_file_to_file_set( file_set, file )
-        #   break if success
-        #   attempts += 1
-        #   file_set = nil
-        # end
         return file_set
       end
 


### PR DESCRIPTION
* The cause of this is that when a new version of a file is uploaded, the depositor overrides the actual uploading user.
* Added debug logging.
* AttachFilesToWorkJob was using: user = User.find_by_user_key( depositor ), which is incorrect when another user replaces a file version
* AttachFilesToWorkJob now looks up the current user
* Made sure current user is being passed into and along the ingest job chain