### PR TITLE
BLUEDOC-426 - Work metadata file should only show public metadata

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -57,6 +57,23 @@ class Collection < ActiveFedora::Base
     ]
   end
 
+  def metadata_keys_report
+    %i[
+      child_collection_count
+      child_work_count
+      collection_type
+      creator
+      curation_notes_user
+      description
+      keyword
+      language
+      referenced_by
+      subject_discipline
+      title
+      total_file_size
+    ]
+  end
+
   def metadata_keys_update
     %i[
       creator
@@ -255,7 +272,7 @@ class Collection < ActiveFedora::Base
   end
 
   def metadata_report_keys
-    return USE_BLANK_KEY_VALUES, metadata_keys_all
+    return IGNORE_BLANK_KEY_VALUES, metadata_keys_report
   end
 
   def metadata_report_label_override( metadata_key:, metadata_value: ) # rubocop:disable Lint/UnusedMethodArgument

--- a/app/models/concerns/deepblue/metadata_behavior.rb
+++ b/app/models/concerns/deepblue/metadata_behavior.rb
@@ -28,6 +28,10 @@ module Deepblue
       %i[]
     end
 
+    def metadata_keys_report
+      %i[]
+    end
+
     def metadata_keys_brief
       %i[]
     end
@@ -91,14 +95,15 @@ module Deepblue
         ignore_blank_values, metadata_keys = metadata_report_keys
         metadata = metadata_hash( metadata_keys: metadata_keys, ignore_blank_values: ignore_blank_values )
         metadata_report_to( out: out, metadata_hash: metadata, depth: depth )
-        contained_objects = metadata_report_contained_objects
-        if contained_objects.count.positive?
-          contained_objects.each do |obj|
-            next unless obj.respond_to? :metadata_report
-            out.puts
-            obj.metadata_report( out: out, depth: depth + 1 )
-          end
-        end
+        # Don't include metadata reports for contained objects, such as file_sets
+        # contained_objects = metadata_report_contained_objects
+        # if contained_objects.count.positive?
+        #   contained_objects.each do |obj|
+        #     next unless obj.respond_to? :metadata_report
+        #     out.puts
+        #     obj.metadata_report( out: out, depth: depth + 1 )
+        #   end
+        # end
         return nil
       end
     end
@@ -116,7 +121,7 @@ module Deepblue
     end
 
     def metadata_report_keys
-      return AbstractEventBehavior::USE_BLANK_KEY_VALUES, []
+      return AbstractEventBehavior::IGNORE_BLANK_KEY_VALUES, metadata_keys_report
     end
 
     def metadata_report_label( metadata_key:, metadata_value: )

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -103,6 +103,31 @@ class DataSet < ActiveFedora::Base
     ]
   end
 
+  def metadata_keys_report
+    %i[
+      authoremail
+      creator
+      curation_notes_user
+      date_coverage
+      depositor
+      description
+      doi
+      fundedby
+      fundedby_other
+      grantnumber
+      keyword
+      language
+      methodology
+      referenced_by
+      rights_license
+      rights_license_other
+      subject_discipline
+      title
+      total_file_count
+      total_file_size_human_readable
+    ]
+  end
+
   def metadata_keys_update
     %i[
       authoremail
@@ -246,7 +271,7 @@ class DataSet < ActiveFedora::Base
   end
 
   def metadata_report_keys
-    return USE_BLANK_KEY_VALUES, metadata_keys_all
+    return IGNORE_BLANK_KEY_VALUES, metadata_keys_report
   end
 
   def metadata_report_label_override( metadata_key:, metadata_value: ) # rubocop:disable Lint/UnusedMethodArgument

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -51,6 +51,21 @@ class FileSet < ActiveFedora::Base
     ]
   end
 
+  def metadata_keys_report
+    %i[
+      curation_notes_user
+      file_extension
+      files_count
+      file_size_human_readable
+      label
+      mime_type
+      original_checksum
+      original_name
+      parent_id
+      title
+    ]
+  end
+
   def metadata_keys_update
     %i[
       title
@@ -234,7 +249,7 @@ class FileSet < ActiveFedora::Base
   end
 
   def metadata_report_keys
-    return USE_BLANK_KEY_VALUES, metadata_keys_all
+    return IGNORE_BLANK_KEY_VALUES, metadata_keys_report
   end
 
   def metadata_report_title_pre

--- a/spec/models/concerns/deepblue/metadata_behavior_spec.rb
+++ b/spec/models/concerns/deepblue/metadata_behavior_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Deepblue::AbstractEventBehavior do
       expect( empty_mock.metadata_hash_override( key: 'key', ignore_blank_values: false, key_values: [ key: 'value' ] ) ).to eq false
       expect( empty_mock.metadata_report_label_override(metadata_key: 'key', metadata_value: 'value' ) ).to eq nil
       ignore_blank_key_values, keys = empty_mock.metadata_report_keys
-      expect( ignore_blank_key_values ).to eq ::Deepblue::AbstractEventBehavior::USE_BLANK_KEY_VALUES
+      expect( ignore_blank_key_values ).to eq ::Deepblue::AbstractEventBehavior::IGNORE_BLANK_KEY_VALUES
       expect( keys ).to eq []
       expect( empty_mock.metadata_report_contained_objects ).to eq []
       expect( empty_mock.metadata_report_title_pre ).to eq ''


### PR DESCRIPTION
* Restricted list of metadata for collectins, file_sets, and works.
* Collections no longer include metadata for sub-collections or works.
* Works no longer include file_sets metadata.