### PR TITLE
BLUEDOC-449 - Pin solr_wrapper to solr v6.6.5

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,7 +1,7 @@
 # Place any default configuration for solr_wrapper here
 # version: 6.0.0
 # currently, deepblue is not compatible with v8+
-version: 7.7.1
+version: 6.6.5
 # port: 8983
 instance_dir: tmp/solr-development
 collection:


### PR DESCRIPTION
* solr v6.6.5 is what we currently use in production