### PR TITLE
BLUEDOC-411 - Look for DOI 'mint now' in yml files related to UMMZ ba…

### DIFF
--- a/app/controllers/hyrax/deepblue_controller.rb
+++ b/app/controllers/hyrax/deepblue_controller.rb
@@ -16,13 +16,17 @@ module Hyrax
       false
     end
 
+    def doi_minting_enabled?
+      false
+    end
+
     def globus_download_enabled?
       false
     end
 
-    def mint_doi_enabled?
-      false
-    end
+    # def mint_doi_enabled?
+    #   false
+    # end
 
     def tombstone_enabled?
       false

--- a/app/jobs/doi_minting_job.rb
+++ b/app/jobs/doi_minting_job.rb
@@ -4,27 +4,53 @@ class DoiMintingJob < ::Hyrax::ApplicationJob
 
   queue_as :doi_minting
 
-  def perform(id)
-    work = ActiveFedora::Base.find(id)
-    user = User.find_by_user_key(work.depositor)
-    Rails.logger.debug "DoiMintingJob work id #{id} #{user.email} starting..."
-
-    # Continue only when doi is pending
-    return unless work.doi.nil? || work.doi == DataSet::DOI_PENDING
-
-    if Deepblue::DoiMintingService.mint_doi_for work
+  def perform( id, current_user: nil, job_delay: 0 )
+    Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                         Deepblue::LoggingHelper.called_from,
+                                         "work.id=#{id}",
+                                         "current_user=#{current_user}",
+                                         "job_delay=#{job_delay}"]
+    if 0 < job_delay
+      return unless ActiveFedora::Base.find( id ).doi_pending?
+      Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                           Deepblue::LoggingHelper.called_from,
+                                           "work.id=#{id}",
+                                           "current_user=#{current_user}",
+                                           "sleeping #{job_delay} seconds"]
+      sleep job_delay
+    end
+    work = ActiveFedora::Base.find( id )
+    Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                         Deepblue::LoggingHelper.called_from,
+                                         "work.id=#{id}",
+                                         Deepblue::LoggingHelper.obj_class( "work", work ),
+                                         "work.doi=#{work.doi}",
+                                         "work.doi_pending?=#{work.doi_pending?}"]
+    return unless work.doi_pending?
+    current_user = work.depositor if current_user.blank?
+    user = User.find_by_user_key( current_user )
+    Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                         Deepblue::LoggingHelper.called_from,
+                                         "work.id=#{id}",
+                                         "user.email=#{user.email}",
+                                         "Starting..." ]
+    # Rails.logger.debug "DoiMintingJob work id #{id} #{user.email} starting..."
+    if Deepblue::DoiMintingService.mint_doi_for( work: work, current_user: current_user )
       Rails.logger.debug "DoiMintingJob work id #{id} #{user.email} succeeded."
       # do success callback
-      if Hyrax.config.callback.set?(:after_doi_success)
-        Hyrax.config.callback.run(:after_doi_success, work, user, log.created_at)
+      if Hyrax.config.callback.set?( :after_doi_success )
+        Hyrax.config.callback.run( :after_doi_success, work, user, log.created_at )
       end
     else
       Rails.logger.debug "DoiMintingJob work id #{id} #{user.email} failed."
       # do failure callback
-      if Hyrax.config.callback.set?(:after_doi_failure)
-        Hyrax.config.callback.run(:after_doi_failure, work, user, log.created_at)
+      if Hyrax.config.callback.set?( :after_doi_failure )
+        Hyrax.config.callback.run( :after_doi_failure, work, user, log.created_at )
       end
     end
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    Rails.logger.error "DoiMintingJob.perform(#{id},#{job_delay}) #{e.class}: #{e.message} at #{e.backtrace[0]}"
+    raise
   end
 
 end

--- a/app/models/concerns/deepblue/doi_behavior.rb
+++ b/app/models/concerns/deepblue/doi_behavior.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Deepblue
+
+  class DoiError < RuntimeError
+  end
+
+  module DoiBehavior
+
+    DOI_MINTING_ENABLED = true
+    DOI_PENDING = 'doi_pending'
+    DOI_MINIMUM_FILE_COUNT = 1
+
+    def doi_minted?
+      !doi.nil?
+    rescue
+      nil
+    end
+
+    def doi_minting_enabled?
+      ::Deepblue::DoiBehavior::DOI_MINTING_ENABLED
+    end
+
+    def doi_pending?
+      doi == DOI_PENDING
+    end
+
+    def doi_mint( current_user: nil, event_note: '', enforce_minimum_file_count: true, job_delay: 0 )
+      Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                           Deepblue::LoggingHelper.called_from,
+                                           "work.id=#{id}",
+                                           "doi=#{doi}",
+                                           "current_user=#{current_user}",
+                                           "event_note=#{event_note}",
+                                           "enforce_minimum_file_count=#{enforce_minimum_file_count}",
+                                           "job_delay=#{job_delay}" ]
+      return false if doi_pending?
+      # Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+      #                                      Deepblue::LoggingHelper.called_from,
+      #                                      "work.id=#{id}",
+      #                                      "past doi_pending?" ]
+      return false if doi_minted?
+      # Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+      #                                      Deepblue::LoggingHelper.called_from,
+      #                                      "work.id=#{id}",
+      #                                      "past doi_minted?" ]
+      return false if enforce_minimum_file_count && file_sets.count < DOI_MINIMUM_FILE_COUNT
+      self.doi = DOI_PENDING
+      self.save
+      self.reload
+      current_user = current_user.email if current_user.respond_to? :email
+      Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                           Deepblue::LoggingHelper.called_from,
+                                           "work.id=#{id}",
+                                           "doi=#{doi}",
+                                           "about to call DoiMintingJob" ]
+      ::DoiMintingJob.perform_later( id, current_user: current_user, job_delay: job_delay )
+      return true
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      Rails.logger.error "DoiBehavior.doi_mint for curation_concern.id #{id} -- #{e.class}: #{e.message} at #{e.backtrace[0]}"
+    end
+
+  end
+
+end

--- a/app/models/concerns/umrdr/solr_document_behavior.rb
+++ b/app/models/concerns/umrdr/solr_document_behavior.rb
@@ -24,6 +24,23 @@ module Umrdr
       Array(self[Solrizer.solr_name('doi')]).first
     end
 
+    def doi_minted?
+      # the first time this is called, doi will not be in solr.
+      # @solr_document[ Solrizer.solr_name( 'doi', :symbol ) ].first
+      doi.first
+    rescue
+      nil
+    end
+
+    def doi_minting_enabled?
+      ::Deepblue::DoiBehavior::DOI_MINTING_ENABLED
+    end
+
+    def doi_pending?
+      #@solr_document[ Solrizer.solr_name( 'doi', :symbol ) ].first == ::Deepblue::DoiBehavior::DOI_PENDING
+      doi.first == ::Deepblue::DoiBehavior::DOI_PENDING
+    end
+
     def file_size
       Array(self['file_size_lts']).first # standard lookup Solrizer.solr_name('file_size')] produces solr_document['file_size_tesim']
     end

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -26,6 +26,7 @@ class DataSet < ActiveFedora::Base
   include ::Deepblue::MetadataBehavior
   include ::Deepblue::EmailBehavior
   include ::Deepblue::ProvenanceBehavior
+  include ::Deepblue::DoiBehavior
 
   after_initialize :set_defaults
 
@@ -34,8 +35,6 @@ class DataSet < ActiveFedora::Base
   def provenance_before_destroy_data_set
     provenance_destroy( current_user: '' ) # , event_note: 'provenance_before_destroy_data_set' )
   end
-
-  DOI_PENDING = 'doi_pending'
 
   def set_defaults
     return unless new_record?

--- a/app/presenters/hyrax/data_set_presenter.rb
+++ b/app/presenters/hyrax/data_set_presenter.rb
@@ -7,6 +7,10 @@ module Hyrax
               :curation_notes_admin,
               :curation_notes_user,
               :date_coverage,
+              :doi,
+              :doi_minted?,
+              :doi_minting_enabled?,
+              :doi_pending?,
               :fundedby,
               :fundedby_other,
               :grantnumber,
@@ -64,27 +68,27 @@ module Hyrax
     # end display_provenance_log
 
     # begin doi
-
-    def doi
-      solr_value = @solr_document[Solrizer.solr_name('doi', :symbol)]
-      return nil if solr_value.blank?
-      solr_value.first
-    end
-
-    def doi_minted?
-      !doi.nil?
-    rescue
-      nil
-    end
-
-    def doi_pending?
-      doi == DataSet::DOI_PENDING
-    end
-
-    def mint_doi_enabled?
-      true
-    end
-
+    #
+    # def doi
+    #   solr_value = @solr_document[Solrizer.solr_name('doi', :symbol)]
+    #   return nil if solr_value.blank?
+    #   solr_value.first
+    # end
+    #
+    # def doi_minted?
+    #   !doi.nil?
+    # rescue
+    #   nil
+    # end
+    #
+    # def doi_pending?
+    #   doi == ::Deepblue::DoiBehavior::DOI_PENDING
+    # end
+    #
+    # def mint_doi_enabled?
+    #   true
+    # end
+    #
     # end doi
 
     # begin globus

--- a/app/presenters/hyrax/deepblue_presenter.rb
+++ b/app/presenters/hyrax/deepblue_presenter.rb
@@ -12,13 +12,17 @@ module Hyrax
       false
     end
 
+    def doi_minting_enabled?
+      false
+    end
+
     def globus_download_enabled?
       false
     end
 
-    def mint_doi_enabled?
-      false
-    end
+    # def mint_doi_enabled?
+    #   false
+    # end
 
     def tombstone_enabled?
       false

--- a/app/presenters/hyrax/ds_file_set_presenter.rb
+++ b/app/presenters/hyrax/ds_file_set_presenter.rb
@@ -4,28 +4,33 @@ module Hyrax
 
   class DsFileSetPresenter < Hyrax::FileSetPresenter
 
-    delegate :title, :file_size,
+    delegate :doi,
+             :doi_minted?,
+             :doi_minting_enabled?,
+             :doi_pending?,
+             :file_size,
              :file_size_human_readable,
              :original_checksum,
              :mime_type,
+             :title,
              :virus_scan_service,
              :virus_scan_status,
              :virus_scan_status_date, to: :solr_document
 
-    def doi_minted?
-      # the first time this is called, doi will not be in solr.
-      @solr_document[ Solrizer.solr_name( 'doi', :symbol ) ].first
-    rescue
-      nil
-    end
+    # def doi_minted?
+    #   # the first time this is called, doi will not be in solr.
+    #   @solr_document[ Solrizer.solr_name( 'doi', :symbol ) ].first
+    # rescue
+    #   nil
+    # end
+    #
+    # def doi_pending?
+    #   @solr_document[ Solrizer.solr_name( 'doi', :symbol ) ].first == ::Deepblue::DoiBehavior::DOI_PENDING
+    # end
 
-    def doi_pending?
-      @solr_document[ Solrizer.solr_name( 'doi', :symbol ) ].first == DataSet::DOI_PENDING
-    end
-
-    def parent_doi?
+    def parent_doi_minted?
       g = DataSet.find parent.id
-      g.doi.present?
+      g.doi_minted?
     end
 
     def parent_public?

--- a/app/services/deepblue/doi_minting_service.rb
+++ b/app/services/deepblue/doi_minting_service.rb
@@ -7,26 +7,34 @@ module Deepblue
     PUBLISHER = "University of Michigan".freeze
     RESOURCE_TYPE = "Dataset".freeze
 
-    attr :work, :metadata
+    attr :current_user, :work, :metadata
 
-    def self.mint_doi_for(work)
-      Rails.logger.debug "DoiMintingService.mint_doi_for( work id = #{work.id} )"
-      service = Deepblue::DoiMintingService.new( work )
-      Rails.logger.debug "DoiMintingService.mint_doi_for calling run"
+    def self.mint_doi_for( work:, current_user: )
+      Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                           Deepblue::LoggingHelper.called_from,
+                                           "work.id=#{work.id}" ]
+      service = Deepblue::DoiMintingService.new( work: work, current_user: current_user )
+      Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                           Deepblue::LoggingHelper.called_from,
+                                           "work.id=#{work.id}",
+                                           "about to call service.run" ]
       service.run
     rescue Exception => e # rubocop:disable Lint/RescueException
-      Rails.logger.debug "DoiMintingService.mint_doi_for( work id = #{work.id} ) rescue exception -- Exception: #{e.class}: #{e.message} at #{e.backtrace[0]}"
+      Rails.logger.debug "DoiMintingService.mint_doi_for( work id = #{work.id}, current_user = #{current_user} ) rescue exception -- Exception: #{e.class}: #{e.message} at #{e.backtrace[0]}"
       unless work.nil?
+        work.reload # consider locking work
         work.doi = nil
         work.save
+        work.reload
         work.doi
       end
       raise
     end
 
-    def initialize(work)
+    def initialize( work:, current_user: )
       Rails.logger.debug "DoiMintingService.initalize( work id = #{work.id} )"
       @work = work
+      @current_user = current_user
       @metadata = generate_metadata
     end
 
@@ -35,8 +43,11 @@ module Deepblue
       rv = doi_server_reachable?
       Rails.logger.debug "DoiMintingService.run doi_server_reachable?=#{rv}"
       return mint_doi_failed unless rv
+      work.reload # consider locking work
       work.doi = mint_doi
       work.save
+      work.reload
+      work.provenance_mint_doi( current_user: current_user, event_note: 'DoiMintingService' )
       work.doi
     end
 
@@ -54,7 +65,7 @@ module Deepblue
       config = Ezid::Client.config
       return [ "Ezid::Client.config.host = #{config.host}",
                "Ezid::Client.config.port = #{config.port}",
-               "Ezid::Client.config.user    = #{config.user}",
+               "Ezid::Client.config.user = #{config.user}",
                # "Ezid::Client.config.password = #{config.password}",
                "Ezid::Client.config.default_shoulder = #{config.default_shoulder}" ]
     end
@@ -79,9 +90,17 @@ module Deepblue
 
       def mint_doi
         # identifier = Ezid::Identifier.create(@metadata)
-        Rails.logger.debug "DoiMintingService.mint_doi( #{metadata} )"
-        msg = ezid_config.join("\n")
-        Rails.logger.debug msg
+        Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                             Deepblue::LoggingHelper.called_from,
+                                             "work.id=#{work.id}",
+                                             "metadata=#{metadata}" ]
+
+        # Rails.logger.debug "DoiMintingService.mint_doi( #{metadata} )"
+        # msg = ezid_config.join("\n")
+        # Rails.logger.debug msg
+        Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                             Deepblue::LoggingHelper.called_from,
+                                             "work.id=#{work.id}" ] + ezid_config
         shoulder = Ezid::Client.config.default_shoulder
         identifier = Ezid::Identifier.mint( shoulder, @metadata )
         identifier.id
@@ -89,8 +108,10 @@ module Deepblue
 
       def mint_doi_failed
         Rails.logger.error "DoiMintingService.mint_doi_failed work id = #{work.id}"
+        work.reload # consider locking work
         work.doi = nil
         work.save
+        work.reload
         work.doi
       end
 

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -89,7 +89,7 @@
       <% end %>
     <% end %>
 
-    <% if @presenter.editor? && @presenter.mint_doi_enabled? %>
+    <% if @presenter.editor? && @presenter.doi_minting_enabled? %>
       <% if @presenter.doi_minted? && @presenter.current_ability.admin? %>
         <%= link_to t('simple_form.actions.data_set.edit'),
                     edit_polymorphic_path([main_app, @presenter]),

--- a/app/views/hyrax/file_sets/_show_actions.html.erb
+++ b/app/views/hyrax/file_sets/_show_actions.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <% if @presenter.editor? %>
-      <% if ( @presenter.parent_doi? && !current_ability.admin? ) %>
+      <% if ( @presenter.parent_doi_minted? && !current_ability.admin? ) %>
       <% else %>
         <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]),
                     class: 'btn btn-default' %>

--- a/config/locales/data_set.en.yml
+++ b/config/locales/data_set.en.yml
@@ -6,6 +6,8 @@ en:
       "A DOI is currently being minted."
     doi_job_started:
       "DOI process kicked off for work id: %{id}"
+    doi_minting_started:
+      "DOI minting has started."
     doi_requires_work_with_files:
       "DOI cannot be minted for a work without files."
     doi_user_without_access:

--- a/spec/models/data_set_spec.rb
+++ b/spec/models/data_set_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe DataSet do
 
   describe 'constants' do
     it do
-      expect( DataSet::DOI_PENDING ).to eq 'doi_pending'
+      expect( ::Deepblue::DoiBehavior::DOI_PENDING ).to eq 'doi_pending'
     end
   end
 

--- a/spec/services/deepblue/doi_minting_service_spec.rb
+++ b/spec/services/deepblue/doi_minting_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Deepblue::DoiMintingService do
 
   context "when minting a new doi" do
-    subject { described_class.new(work) }
+    subject { described_class.new( work: work, current_user: "test_doi_minting_service@umich.edu" ) }
     let(:work) { mock_model(GenericWork, id: '123', title: ['demotitle'],
                                          creator: ['Smith, John', 'Smith, Jane', 'O\'Rielly, Kelly'])}
     let(:work_url) { "umrdr-testing.hydra.lib.umich.edu/concern/work/#{work.id}" }
@@ -15,8 +15,10 @@ describe Deepblue::DoiMintingService do
     before do
       allow(Rails).to receive_message_chain("application.routes.url_helpers.hyrax_data_set_url").and_return(work_url)
       allow(work).to receive(:save)
+      allow(work).to receive(:reload)
       allow(work).to receive(:doi).and_return(identifier.id)
       allow(work).to receive(:doi=)
+      allow(work).to receive(:provenance_mint_doi)
       allow(subject).to receive(:doi_server_reachable?).and_return(true)
       allow(Ezid::Identifier).to receive(:mint).and_return(identifier)
     end
@@ -59,9 +61,10 @@ describe Deepblue::DoiMintingService do
   context "when actually calling out to service" do
     let(:work) { GenericWork.new(id: '123', title: ['demotitle'],
                                  creator: ['Smith, John', 'Smith, Jane', 'O\'Rielly, Kelly'])}
+    let( :current_user ) { "test_doi_minting_service@umich.edu" }
     it "mints a doi" do
       skip unless ENV['INTEGRATION']
-      expect(described_class.mint_doi_for(work)).to start_with 'doi:10.5072/FK2'
+      expect(described_class.mint_doi_for( work: work, current_user: current_user ) ).to start_with 'doi:10.5072/FK2'
     end
   end
 


### PR DESCRIPTION
…tch upload

* Added mint DOI flag to new_content_service
** invoked by setting the doi field as doi: 'mint_now'
* Split doi minting behavior out into it's own module
* Regularized doi-related method names to be of the form doi*
* Moved doi related solr methods into umrdr/solr_document_behavior module
* Added sleep delay to doi mint job (so batch minting can be spread out)
* Moved provenance log entry call to where doi is actually minted and returned.