### PR TITLE
BLUEDOC-515 - Favicon reference causes routing error

### DIFF
--- a/app/views/_head_tag_extras.html.erb
+++ b/app/views/_head_tag_extras.html.erb
@@ -1,1 +1,1 @@
-<link rel="icon" href="favicon.ico" type="image/ico"/>
+<!-- link rel="icon" href="favicon.ico" type="image/ico"/ -->


### PR DESCRIPTION
* commented out reference to favicon.ico