### PR TITLE
BLUEDOC-524 Move title under banner image

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -412,6 +412,20 @@ table.table.table-striped.related-files  {
   left: 5px;
 }
 
+/** Edit Work/User Collection **/
+.set-access-controls h3, 
+.set-access-controls label,
+.section-add-sharing h3,
+.section-collection-sharing legend,
+.section-collection-sharing h3 {
+  font-weight: bold;
+  font-size: 1.05em;
+}
+
+div.branding-banner-row {
+    border-top: 0;
+}
+
 /** Work Details **/
 
 .work-details-container {
@@ -597,23 +611,66 @@ div.facets h3 {
 }
 
 /** Collections **/
+
+.hyc-container {
+  margin-top: 1em;
+}
+
 .hyc-generic .hyc-title h1 {
   font-size: 1.5em;
   padding-top: 1em;
 }
 
 .hyc-banner {
-  margin: 1em 0;
+  margin-top: .5em;
+  border-radius: 0;
+  min-height: 145px;
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 -2px 4px 0 rgba(0, 0, 0, 0.24);
 }
 
-.hyc-banner .hyc-title {
-  h1 {
-    font-size:2em;
+.hyc-title-row {
+  background-color: #fff;
+  box-shadow: 0 0 2px 0 rgba(0,0,0,0.12),0 2px 4px 0 rgba(0,0,0,0.24);
+  width: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-flow: row wrap;
+          flex-flow: row wrap;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+          align-items: center;
+  margin-bottom: 2em;
+  padding: .75em 0;
+
+  .hyc-title-under-banner {
+    font-size: 1.55em;
+    color:#000;
+    padding-left: .5em;
+    padding-right: .5em;
+  -webkit-box-flex: 2;
+  -ms-flex-positive: 2;
+          flex-grow: 2;
   }
-   h1.no-banner-text {
-    color: #000;
-    text-shadow:none;
-    font-size:2em;
+}
+
+.hyc-bugs  {
+  margin-left: auto;
+
+  .hyc-last-updated {
+    padding-right: .5em;
+    padding-left: .5em;
+  }
+}
+
+.hyc-logos {
+  padding-left: .5em;
+  padding-top: .5em;  
+
+  img {
+    max-width: 50px;
   }
 }
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -2,15 +2,16 @@
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <div class="col-md-12">
+      <section>
+        <!-- Banner container -->
+        <div class="hyc-banner" <%= @presenter.banner_file.blank? ? "style=display:none" : raw( "style=\"background-image:url(" ) + @presenter.banner_file + raw( ")\"" ) %> >
+        </div>
 
-      <header class="hyc-banner" <%= @presenter.banner_file.blank? ? '' : raw( "style=\"background-image:linear-gradient(rgba(0,0,0,0.5),rgba(0,0,0,0.7)),url(" ) + @presenter.banner_file + raw( ")\"" ) %> >
-
-      <div class="hyc-title">
-        <h1 <%= @presenter.banner_file.blank? ? "class=no-banner-text" : '' %> >
-        <%= @presenter.title.first %></h1>
-      </div>
-
-      <% unless @presenter.logo_record.blank? %>
+        <!-- Title Row -->
+       <div class="hyc-title">
+        <div class="hyc-title-row">
+          <!-- Logo option -->
+       <% unless @presenter.logo_record.blank? %>
           <div class="hyc-logos">
             <% @presenter.logo_record.each_with_index  do |lr, i| %>
 
@@ -24,12 +25,15 @@
             <% end %>
           </div>
       <% end %>
-
-      <div class="hyc-bugs">
-          <div class="hyc-last-updated"><%= @presenter.permission_badge %></div>
+          <h1 class="hyc-title-under-banner"><%= @presenter.title.first %></h1>
+          <div class="hyc-bugs">
+            <!-- Permission Badge -->
+              <div class="hyc-last-updated"><%= @presenter.permission_badge %></div>
+          </div>
+          </div>
+        </div>
       </div>
-
-      </header>
+      </section>
 
     </div>
   </div>


### PR DESCRIPTION
After approval from RDS, moved the title below the banner image. Also removed the `header` tag for accessible markup.