### PR TITLE
BLUEDOC-470 Add list item breaks for citations

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -491,6 +491,13 @@ ul.tabular {
   }
 }
 
+ul.tabular li.attribute-referenced_by,
+ul.tabular li.attribute-creator,
+ul.tabular li.attribute-fundedby {
+  display: list-item;
+  padding: .35em 0;
+}
+
 .data-set-table {
   border: 1px solid #e3e3e3;
   border-radius: 3px;


### PR DESCRIPTION
Added the list-item display back for citations, funding, and creator. Those fields lend themselves to the list item display rather than the inline view used for keywords, etc...