### PR TITLE
BLUEDOC-576 - Version of ingest script that takes multiple input files

### DIFF
--- a/lib/append_content_service.rb
+++ b/lib/append_content_service.rb
@@ -5,7 +5,7 @@ require 'tasks/new_content_service'
 # Given a configuration hash read from a yaml file, build the contents in the repository.
 class AppendContentService < Deepblue::NewContentService
 
-  def self.call( path_to_yaml_file:, ingester: nil, mode: nil, options: )
+  def self.call( path_to_yaml_file:, ingester: nil, mode: nil, first_label: 'work_id', options: )
     cfg_hash = Deepblue::NewContentService.load_yaml_file( path_to_yaml_file )
     return if cfg_hash.nil?
     base_path = File.dirname( path_to_yaml_file )
@@ -13,6 +13,7 @@ class AppendContentService < Deepblue::NewContentService
                                     path_to_yaml_file: path_to_yaml_file,
                                     cfg_hash: cfg_hash,
                                     ingester: ingester,
+                                    first_label: first_label,
                                     mode: mode,
                                     base_path: base_path )
     bcs.run
@@ -20,7 +21,8 @@ class AppendContentService < Deepblue::NewContentService
     Rails.logger.error "AppendContentService.call(#{path_to_yaml_file}) #{e.class}: #{e.message} at\n#{e.backtrace.join("\n")}"
   end
 
-  def initialize( options:, path_to_yaml_file:, cfg_hash:, base_path:, ingester:, mode: )
+  def initialize( options:, path_to_yaml_file:, cfg_hash:, base_path:, ingester:, mode:, first_label: )
+    @first_label = first_label
     initialize_with_msg( options: options,
                          path_to_yaml_file: path_to_yaml_file,
                          cfg_hash: cfg_hash,
@@ -36,7 +38,7 @@ class AppendContentService < Deepblue::NewContentService
       # user = find_or_create_user
       find_works_and_add_files
       # build_collections
-      report_measurements( first_label: 'work id' )
+      report_measurements( first_label: @first_label )
     end
 
 end

--- a/lib/build_content_service.rb
+++ b/lib/build_content_service.rb
@@ -6,7 +6,7 @@ require 'tasks/new_content_service'
 # build the contents in the repository.
 class BuildContentService < Deepblue::NewContentService
 
-  def self.call( path_to_yaml_file:, mode: nil, ingester: nil, options: )
+  def self.call( path_to_yaml_file:, mode: nil, ingester: nil, first_label: 'id', options: )
     cfg_hash = Deepblue::NewContentService.load_yaml_file( path_to_yaml_file )
     return if cfg_hash.nil?
     base_path = File.dirname( path_to_yaml_file )
@@ -15,13 +15,15 @@ class BuildContentService < Deepblue::NewContentService
                                    base_path: base_path,
                                    mode: mode,
                                    ingester: ingester,
+                                   first_label: first_label,
                                    options: options )
     bcs.run
   rescue Exception => e
     Rails.logger.error "BuildContentService.call(#{path_to_yaml_file}) #{e.class}: #{e.message} at\n#{e.backtrace.join("\n")}"
   end
 
-  def initialize( path_to_yaml_file:, cfg_hash:, base_path:, mode:, ingester:, options: )
+  def initialize( path_to_yaml_file:, cfg_hash:, base_path:, mode:, ingester:, first_label:, options: )
+    @first_label = first_label
     initialize_with_msg( options: options,
                          path_to_yaml_file: path_to_yaml_file,
                          cfg_hash: cfg_hash,
@@ -36,7 +38,7 @@ class BuildContentService < Deepblue::NewContentService
     def build_repo_contents
       build_works
       build_collections
-      report_measurements( first_label: 'id' )
+      report_measurements( first_label: @first_label )
     rescue Exception => e
       Rails.logger.error "BuildContentService.build_repo_contents #{e.class}: #{e.message} at\n#{e.backtrace.join("\n")}"
     end

--- a/lib/tasks/new_content_from_yaml.rake
+++ b/lib/tasks/new_content_from_yaml.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative './new_content_from_yaml'
+
+namespace :deepblue do
+
+  # bundle exec rake deepblue:new_content_from_yaml['f4752g72m g4752g72m','{"source_dir":"/deepbluedata-prep"\,"mode":"build"\,"prefix":""\,"postfix":"_populate"\,"ingester":"ingester@umich.edu"}']
+  desc 'New content from yaml files (base file names separated by spaces)'
+  task :new_content_from_yaml, %i[ base_file_names options ] => :environment do |_task, args|
+    args.with_defaults( options: '{}' )
+    task = Deepblue::NewContentFromYaml.new( base_file_names: args[:base_file_names],
+                                             options: args[:options] )
+    task.run
+  end
+
+end

--- a/lib/tasks/new_content_from_yaml.rb
+++ b/lib/tasks/new_content_from_yaml.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module Deepblue
+
+  require 'open-uri'
+  require 'tasks/abstract_task'
+  require 'tasks/task_helper'
+  require 'tasks/new_content_service'
+  require_relative '../append_content_service'
+  require_relative '../build_content_service'
+  require_relative '../update_content_service'
+  require 'benchmark'
+  include Benchmark
+
+  class NewContentFromYaml < AbstractTask
+
+    DEFAULT_SOURCE_DIR = '/deepbluedata-prep'
+    DEFAULT_INGESTER = nil
+    DEFAULT_MODE = "populate"
+    DEFAULT_PREFIX = ""
+    DEFAULT_POSTFIX = ""
+
+    def initialize( base_file_names:, options: )
+      super( options: options )
+      @test = false
+      @base_file_names = base_file_names.split( ' ' )
+      @ingester = task_options_value( key: 'ingester', default_value: DEFAULT_INGESTER )
+      @mode = task_options_value( key: 'mode', default_value: DEFAULT_MODE )
+      @prefix = task_options_value( key: 'prefix', default_value: DEFAULT_PREFIX )
+      @postfix = task_options_value( key: 'postfix', default_value: DEFAULT_POSTFIX )
+      @source_dir = Pathname.new task_options_value( key: 'source_dir', default_value: DEFAULT_SOURCE_DIR )
+    end
+
+    def expand_file_names( base_file_names )
+      file_names = []
+      Array( base_file_names ).each do |base_file_name|
+        file_name = @source_dir.join "#{@prefix}#{base_file_name}#{@postfix}.yml"
+        file_names << file_name.to_s
+      end
+      file_names
+    end
+
+    # def report_collection( first_id:, measurements:, total: nil )
+    #   # TaskHelper.benchmark_report( label: 'coll id', first_id: first_id, measurements: measurements, total: total )
+    # end
+    #
+    # def report_users( first_id:, measurements:, total: nil )
+    #   # TaskHelper.benchmark_report( label: 'users', first_id: first_id, measurements: measurements, total: total )
+    # end
+
+    def report_stats
+
+    end
+
+    def report_work( first_id:, measurements:, total: nil )
+      TaskHelper.benchmark_report( label: first_id, first_id: first_id, measurements: measurements, total: total )
+    end
+
+    def run
+      return if @base_file_names.blank?
+      file_names = expand_file_names(@base_file_names )
+      measurements, total = run_multiple( file_names: file_names )
+      report_stats
+      first_id = File.basename( file_names[0], ".*" )
+      report_work( first_id: first_id, measurements: measurements, total: total )
+    end
+
+    def run_multiple( file_names: )
+      total = nil
+      measurements = []
+      file_names.each do |file_name|
+        first_label = File.basename( file_name, ".*" )
+        subtotal = case @mode
+                   when NewContentService::MODE_APPEND
+                     append_one( file_name: file_name, first_label: first_label )
+                   when NewContentService::MODE_BUILD
+                     build_one( file_name: file_name, first_label: first_label )
+                   when NewContentService::MODE_MIGRATE
+                     migrate_one( file_name: file_name, first_label: first_label )
+                   when NewContentService::MODE_UPDATE
+                     update_one( file_name: file_name, first_label: first_label )
+                   else
+                     puts "Don't know how to #{@mode} file '#{file_name}"
+                     0
+                   end
+        measurements << subtotal
+        if total.nil?
+          total = subtotal
+        else
+          total += subtotal
+        end
+      end
+      return measurements, total
+    end
+
+    def append_one( file_name:, first_label: )
+      measurement = Benchmark.measure( file_name ) do
+        puts "Appending content using yaml file '#{file_name}'"
+        AppendContentService.call( path_to_yaml_file: file_name,
+                                   ingester: @ingester,
+                                   first_label: first_label,
+                                   options: @options ) unless @test
+      end
+      return measurement
+    end
+
+    def build_one( file_name:, first_label: )
+      measurement = Benchmark.measure( file_name ) do
+        puts "Building content using yaml file '#{file_name}'"
+        BuildContentService.call( path_to_yaml_file: file_name,
+                                  ingester: @ingester,
+                                  first_label: first_label,
+                                  options: @options ) unless @test
+      end
+      return measurement
+    end
+
+    def migrate_one( file_name:, first_label: )
+      measurement = Benchmark.measure( file_name ) do
+        puts "Migrating content using yaml file '#{file_name}'"
+        BuildContentService.call( path_to_yaml_file: file_name,
+                                  mode: MODE_MIGRATE,
+                                  ingester: @ingester,
+                                  first_label: first_label,
+                                  options: @options ) unless @test
+      end
+      return measurement
+    end
+
+    def update_one( file_name:, first_label: )
+      measurement = Benchmark.measure( file_name ) do
+        puts "Updating content using yaml file '#{file_name}'"
+        UpdateContentService.call( path_to_yaml_file: file_name,
+                                   ingester: @ingester,
+                                   first_label: first_label,
+                                   options: @options ) unless @test
+      end
+      return measurement
+    end
+
+  end
+
+end

--- a/lib/update_content_service.rb
+++ b/lib/update_content_service.rb
@@ -5,7 +5,7 @@ require 'tasks/new_content_service'
 # Given a configuration hash read from a yaml file, build the contents in the repository.
 class UpdateContentService < Deepblue::NewContentService
 
-  def self.call( path_to_yaml_file:, ingester: nil, options: )
+  def self.call( path_to_yaml_file:, ingester: nil, first_label: 'work id', options: )
     cfg_hash = Deepblue::NewContentService.load_yaml_file( path_to_yaml_file )
     return if cfg_hash.nil?
     base_path = File.dirname( path_to_yaml_file )
@@ -13,6 +13,7 @@ class UpdateContentService < Deepblue::NewContentService
                                     path_to_yaml_file: path_to_yaml_file,
                                     cfg_hash: cfg_hash,
                                     ingester: ingester,
+                                    first_label: first_label,
                                     base_path: base_path )
     bcs.run
   rescue Exception => e # rubocop:disable Lint/RescueException
@@ -20,7 +21,8 @@ class UpdateContentService < Deepblue::NewContentService
     Rails.logger.error "UpdateContentService.call(#{path_to_yaml_file}) #{e.class}: #{e.message} at\n#{e.backtrace.join("\n")}"
   end
 
-  def initialize( options:, path_to_yaml_file:, cfg_hash:, base_path:, ingester: )
+  def initialize( options:, path_to_yaml_file:, cfg_hash:, base_path:, ingester:, first_label: )
+    @first_label = first_label
     initialize_with_msg( options: options,
                          path_to_yaml_file: path_to_yaml_file,
                          cfg_hash: cfg_hash,
@@ -35,7 +37,7 @@ class UpdateContentService < Deepblue::NewContentService
     def build_repo_contents
       update_collections
       update_works
-      report_measurements( first_label: 'work id' )
+      report_measurements( first_label: @first_label )
     rescue Exception => e # rubocop:disable Lint/RescueException
       puts "UpdateContentService.build_repo_contents #{e.class}: #{e.message} at\n#{e.backtrace.join("\n")}"
       Rails.logger.error "UpdateContentService.build_repo_contents #{e.class}: #{e.message} at\n#{e.backtrace.join("\n")}"


### PR DESCRIPTION
Add a version of the ingest scripts that will take multiple input files so that a single rake invocation can ingest multiple files and avoid the start-up overhead for invoking rake for each file