### PR TITLE
BLUEDOC-547 - Embargo date and pick choice should display consistently 2

### DIFF
--- a/app/models/concerns/deepblue/provenance_behavior.rb
+++ b/app/models/concerns/deepblue/provenance_behavior.rb
@@ -537,6 +537,7 @@ module Deepblue
     end
 
     def provenance_unembargo( current_user:, event_note: '', message: '', embargo_visibility:, embargo_visibility_after: )
+      return if id.blank? # this will happen when attempting to set an invalid embargo release date during work creation
       attributes, ignore_blank_key_values = attributes_for_provenance_embargo
       prov_key_values = provenance_attribute_values_for_snapshot( attributes: attributes,
                                                                   current_user: current_user,

--- a/app/models/concerns/deepblue/workflow_event_behavior.rb
+++ b/app/models/concerns/deepblue/workflow_event_behavior.rb
@@ -13,7 +13,9 @@ module Deepblue
                                              Deepblue::LoggingHelper.obj_class( 'class', self ),
                                              "current_user=#{current_user}",
                                              "event_note=#{event_note}",
+                                             "id=#{id}",
                                              "" ]
+      return if id.blank?
       provenance_create( current_user: current_user, event_note: event_note )
       email_event_create_rds( current_user: current_user, event_note: event_note )
       email_event_create_user( current_user: current_user, event_note: event_note )


### PR DESCRIPTION
Fixed case where embargo date is illegal during create causes error