### PR TITLE
BLUEDOC-744 - Fix solr config

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -3,6 +3,7 @@
 # development invocation. See config/solr_wrapper_test.yml for test values.
 # Currently, deepblue is not compatible with Solr 8.0+
 # version: 6.6.5
+version: 7.7.1
 port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,6 +1,7 @@
 # Test configuration; used by the `ci` rake task. Can also be specified with
 # a --config option to run standalone for tests.
 # version: 6.6.5
+version: 7.7.1
 port: 8985
 instance_dir: tmp/solr-test
 collection:


### PR DESCRIPTION
solr started failing to load. Set the solr version to 7.7.1