### PR TITLE
when updating version of file, make sure the cache is refreshed.

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -126,6 +126,7 @@ module Hyrax
                                                "actor.update_content" ] if FILE_SETS_CONTROLLER_DEBUG_VERBOSE
           uploaded_files = Array(Hyrax::UploadedFile.find(params[:files_files]))
           actor.update_content(uploaded_files.first)
+          update_metadata
         end
       end
 


### PR DESCRIPTION
Fixes issue #548.  This update of the metadata will set a new Las-Modified date on the header of the file being downloaded, that will ensure that files with the same name are not downloaded from the cache.