### PR TITLE
BLUEDOC-858 - Re-order files function is not working

### DIFF
--- a/app/assets/javascripts/hyrax/collections_utils.es6
+++ b/app/assets/javascripts/hyrax/collections_utils.es6
@@ -41,7 +41,7 @@ class AddParticipants {
 
     $.ajax({
       type: 'POST',
-      url: "<%=::DeepBlueDocs::Application.config.relative_url_root%>" + url,
+      url: "/data" + url, // monkey: <%=::DeepBlueDocs::Application.config.relative_url_root%>
       data: serialized
     })
       .done(function(response) {

--- a/app/assets/javascripts/hyrax/file_manager/sorting.es6
+++ b/app/assets/javascripts/hyrax/file_manager/sorting.es6
@@ -19,7 +19,7 @@ export default class SortManager {
     this.element.removeClass("success")
     this.element.removeClass("failure")
     let persisting = $.post(
-      `<%= ::DeepBlueDocs::Application.config.relative_url_root %>/concern/${this.class_name}/${this.id}.json`, // monkey
+      `/data/concern/${this.class_name}/${this.id}.json`, // monkey: <%= ::DeepBlueDocs::Application.config.relative_url_root %>
       this.params()
     ).done((response) => {
       this.element.data('version', response.version)

--- a/app/controllers/concerns/deepblue/works_controller_behavior.rb
+++ b/app/controllers/concerns/deepblue/works_controller_behavior.rb
@@ -14,7 +14,7 @@ module Deepblue
     include Deepblue::DoiControllerBehavior
     include Deepblue::IngestAppendScriptControllerBehavior
 
-    WORKS_CONTROLLER_BEHAVIOR_DEBUG_VERBOSE = false
+    WORKS_CONTROLLER_BEHAVIOR_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.works_controller_behavior_debug_verbose
 
     class_methods do
       def curation_concern_type=(curation_concern_type)

--- a/app/controllers/hyrax/data_sets_controller.rb
+++ b/app/controllers/hyrax/data_sets_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
 
     PARAMS_KEY = 'data_set'
 
-    DATA_SETS_CONTROLLER_DEBUG_VERBOSE = true
+    DATA_SETS_CONTROLLER_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.data_sets_controller_debug_verbose
 
     include ::Deepblue::WorksControllerBehavior
 

--- a/app/controllers/hyrax/downloads_controller.rb
+++ b/app/controllers/hyrax/downloads_controller.rb
@@ -5,7 +5,7 @@ module Hyrax
   class DownloadsController < ApplicationController
 
     # begin monkey
-    DOWNLOADS_CONTROLLER_DEBUG_VERBOSE = true
+    DOWNLOADS_CONTROLLER_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.downloads_controller_debug_verbose
     # end monkey
 
     include Hydra::Controller::DownloadBehavior

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -7,7 +7,7 @@ module Hyrax
   # monkey patch FileSetsController
   class FileSetsController < ApplicationController
 
-    FILE_SETS_CONTROLLER_DEBUG_VERBOSE = true
+    FILE_SETS_CONTROLLER_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.file_sets_controller_debug_verbose
 
     include Deepblue::DoiControllerBehavior
 

--- a/app/helpers/deepblue/interpolation_helper.rb
+++ b/app/helpers/deepblue/interpolation_helper.rb
@@ -4,7 +4,7 @@ module Deepblue
 
   module InterpolationHelper
 
-    INTERPOLATION_HELPER_DEBUG_VERBOSE = true
+    INTERPOLATION_HELPER_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.interpolation_helper_debug_verbose
 
     INTERPOLATION_PATTERN = I18n::INTERPOLATION_PATTERN
 

--- a/app/models/concerns/deepblue/email_behavior.rb
+++ b/app/models/concerns/deepblue/email_behavior.rb
@@ -10,7 +10,7 @@ module Deepblue
   module EmailBehavior
     include AbstractEventBehavior
 
-    EMAIL_BEHAVIOR_DEBUG_VERBOSE = true
+    EMAIL_BEHAVIOR_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.email_behavior_debug_verbose
 
     def attributes_all_for_email
       %i[]

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -15,7 +15,7 @@ module Hyrax
     attr_accessor :parent_collections # This is expected to be a Blacklight::Solr::Response with all of the parent collections
     attr_writer :collection_type
 
-    COLLECTION_PRESENTER_DEBUG_VERBOSE = true
+    COLLECTION_PRESENTER_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.collection_presenter_debug_verbose
 
     class_attribute :create_work_presenter_class
     self.create_work_presenter_class = Hyrax::SelectTypeListPresenter

--- a/app/services/deepblue/work_view_content_service.rb
+++ b/app/services/deepblue/work_view_content_service.rb
@@ -4,8 +4,8 @@ module Deepblue
 
   module WorkViewContentService
 
-    WORK_VIEW_CONTENT_SERVICE_DEBUG_VERBOSE = false
-    WORK_VIEW_CONTENT_SERVICE_EMAIL_TEMPLATES_DEBUG_VERBOSE = true
+    WORK_VIEW_CONTENT_SERVICE_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.work_view_content_service_debug_verbose
+    WORK_VIEW_CONTENT_SERVICE_EMAIL_TEMPLATES_DEBUG_VERBOSE = ::DeepBlueDocs::Application.config.work_view_content_service_email_templates_debug_verbose
 
     include ::Deepblue::InitializationConstants
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -203,7 +203,7 @@ module DeepBlueDocs
     config.virus_scan_retry_on_unknown = false
 
     # begin rest_api config
-    config.rest_api_allow_mutate = false
+    config.rest_api_allow_mutate = true
     config.rest_api_allow_read = true
     # end rest_api config
 
@@ -224,6 +224,18 @@ module DeepBlueDocs
       Deepblue::WorkViewContentService.load_email_templates
       # puts "Finished after initialize."
     end
+
+    # debug_verbose flags
+    config.collection_presenter_debug_verbose = true # COLLECTION_PRESENTER_DEBUG_VERBOSE = true
+    config.data_sets_controller_debug_verbose = true # DATA_SETS_CONTROLLER_DEBUG_VERBOSE = true
+    config.downloads_controller_debug_verbose = true # DOWNLOADS_CONTROLLER_DEBUG_VERBOSE = true
+    config.email_behavior_debug_verbose = true # EMAIL_BEHAVIOR_DEBUG_VERBOSE = true
+    config.file_sets_controller_debug_verbose = true # FILE_SETS_CONTROLLER_DEBUG_VERBOSE = true
+    config.interpolation_helper_debug_verbose = true # INTERPOLATION_HELPER_DEBUG_VERBOSE = true
+    config.works_controller_behavior_debug_verbose = true # WORKS_CONTROLLER_BEHAVIOR_DEBUG_VERBOSE = true
+    config.work_view_content_service_debug_verbose = false # WORK_VIEW_CONTENT_SERVICE_DEBUG_VERBOSE = false
+    config.work_view_content_service_email_templates_debug_verbose = true # WORK_VIEW_CONTENT_SERVICE_EMAIL_TEMPLATES_DEBUG_VERBOSE = true
+
 
   end
 


### PR DESCRIPTION
The expansions of default url not working for javascript.

Turns out that this function using a rest/json call. Restoring
json update/mutate ability.