### PR TITLE
BLUEDOC-869 Add new link for logo

### DIFF
--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -383,7 +383,7 @@ en:
     site_logo_href:         "https://www.lib.umich.edu/"
     site_logo_img_html: >
      <img class="site-logo"
-          src="https://www.lib.umich.edu/falafel/v0/graphics/mlib_square__transparent.svg"
+          src="https://apps.lib.umich.edu/falafel/v0/graphics/mlib_square__transparent.svg"
           alt="University of Michigan">
     site_marketing_header: "Browse or Deposit Work in Deep Blue Data"
     site_powered_by_html: >


### PR DESCRIPTION
The new website launch broke the link for the existing "M" logo. This commit adds the apps redirect for the previous link.

The Design System team is going to work on stable asset linking but for now, the redirect should be fine.