### PR TITLE
enable sword in deep blue data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'linkeddata', '<= 3.1.1'
 gem 'rdf-rdfa', '< 3.1.1'
 gem 'rdf-vocab', '<= 3.1.4'
 
-gem 'mysql2' # still somehow in 0.x releases...
+#gem 'mysql2' # still somehow in 0.x releases...
 
 gem 'config'
 
@@ -78,7 +78,7 @@ gem 'jbuilder', '~> 2.5'
 #      https://tools.lib.umich.edu/jira/browse/HELIO-1450
 # gem 'rack', git: 'https://github.com/rack/rack.git', ref: 'ee01748'
 
-gem 'willow_sword', git: 'https://github.com/CottageLabs/willow_sword.git'
+gem 'willow_sword', git: 'https://github.com/CottageLabs/willow_sword.git', branch: 'develop'
 
 # gem 'samvera-persona' #, '0.1.7'
 # gem 'samvera-persona', :github => 'samvera-labs/samvera-persona', :branch => 'remove-generator-config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,19 @@
 GIT
   remote: https://github.com/CottageLabs/willow_sword.git
-  revision: 039adf7bf28b5a517a4e3f221b5d2a31ad077e88
+  revision: 7e3eaf06afa5f5f41b9c20ecf6a0aad8873372ab
+  branch: develop
   specs:
     willow_sword (0.2.0)
       bagit (~> 0.4.1)
+      libxml-ruby (~> 3.1.0)
       rails (>= 5.1.6)
       rubyzip (>= 1.0.0)
 
 GIT
   remote: https://github.com/mlibrary/irus_analytics
-  revision: 52d33547e2a773c62c17398ece9258083f558e2e
+  revision: 0de9a17b2f764a0ce7bdd1d0221c60b88c2643e7
   specs:
-    irus_analytics (1.0.2)
+    irus_analytics (1.0.3)
       config_files
       i18n
       openurl
@@ -110,8 +112,8 @@ GEM
     awesome_nested_set (3.4.0)
       activerecord (>= 4.0.0, < 7.0)
     aws-eventstream (1.1.1)
-    aws-partitions (1.469.0)
-    aws-sdk-core (3.114.3)
+    aws-partitions (1.472.0)
+    aws-sdk-core (3.115.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -267,7 +269,7 @@ GEM
     dry-events (0.3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
-    dry-inflector (0.2.0)
+    dry-inflector (0.2.1)
     dry-initializer (3.0.4)
     dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -278,7 +280,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer
-    dry-schema (1.6.2)
+    dry-schema (1.7.0)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.8, >= 0.8.3)
       dry-core (~> 0.5, >= 0.5)
@@ -357,28 +359,27 @@ GEM
     google-api-client (0.53.0)
       google-apis-core (~> 0.1)
       google-apis-generator (~> 0.1)
-    google-apis-core (0.3.0)
+    google-apis-core (0.4.0)
       addressable (~> 2.5, >= 2.5.1)
-      googleauth (~> 0.14)
-      httpclient (>= 2.8.1, < 3.0)
+      googleauth (>= 0.16.2, < 2.a)
+      httpclient (>= 2.8.1, < 3.a)
       mini_mime (~> 1.0)
       representable (~> 3.0)
-      retriable (>= 2.0, < 4.0)
+      retriable (>= 2.0, < 4.a)
       rexml
-      signet (~> 0.14)
       webrick
-    google-apis-discovery_v1 (0.4.0)
-      google-apis-core (~> 0.1)
-    google-apis-drive_v3 (0.8.0)
-      google-apis-core (~> 0.1)
-    google-apis-generator (0.3.0)
+    google-apis-discovery_v1 (0.5.0)
+      google-apis-core (>= 0.3, < 2.a)
+    google-apis-drive_v3 (0.10.0)
+      google-apis-core (>= 0.3, < 2.a)
+    google-apis-generator (0.4.0)
       activesupport (>= 5.0)
       gems (~> 1.2)
-      google-apis-core (~> 0.1)
-      google-apis-discovery_v1 (~> 0.0)
+      google-apis-core (>= 0.4, < 2.a)
+      google-apis-discovery_v1 (~> 0.5)
       thor (>= 0.20, < 2.a)
-    google-apis-sheets_v4 (0.6.0)
-      google-apis-core (~> 0.1)
+    google-apis-sheets_v4 (0.7.0)
+      google-apis-core (>= 0.3, < 2.a)
     google_drive (3.0.7)
       google-apis-drive_v3 (>= 0.5.0, < 1.0.0)
       google-apis-sheets_v4 (>= 0.4.0, < 1.0.0)
@@ -584,6 +585,7 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
+    libxml-ruby (3.1.0)
     link_header (0.0.8)
     linkeddata (3.1.1)
       equivalent-xml (~> 0.6)
@@ -634,7 +636,6 @@ GEM
     mime-types-data (3.2021.0225)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.3)
     minitest (5.14.4)
     mono_logger (1.1.1)
     multi_json (1.15.0)
@@ -642,7 +643,6 @@ GEM
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.3)
     nest (3.2.0)
       redic
     net-http-persistent (4.0.1)
@@ -653,8 +653,7 @@ GEM
     noid-rails (3.0.3)
       actionpack (>= 5.0.0, < 7)
       noid (~> 0.9)
-    nokogiri (1.11.7)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -696,12 +695,12 @@ GEM
     pretender (0.3.4)
       actionpack (>= 4.2)
     prometheus-client (2.1.0)
-    pry (0.14.1)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
+      pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
@@ -1087,7 +1086,7 @@ GEM
     yabeda (0.9.0)
       concurrent-ruby
       dry-initializer
-    yabeda-prometheus (0.6.1)
+    yabeda-prometheus (0.6.2)
       prometheus-client (>= 0.10, < 3.0)
       rack
       yabeda (~> 0.5)
@@ -1100,7 +1099,7 @@ GEM
       yabeda (~> 0.8)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   active_scheduler
@@ -1135,7 +1134,6 @@ DEPENDENCIES
   linkeddata (<= 3.1.1)
   listen (~> 3.0.5)
   loofah (~> 2.3.1)
-  mysql2
   net-ldap
   nokogiri (>= 1.11.4)
   okcomputer (~> 1.17)
@@ -1191,4 +1189,4 @@ DEPENDENCIES
   yabeda-rails
 
 BUNDLED WITH
-   2.1.4
+   2.2.12

--- a/app/actors/hyrax/actors/after_optimistic_lock_validator.rb
+++ b/app/actors/hyrax/actors/after_optimistic_lock_validator.rb
@@ -14,27 +14,27 @@ module Hyrax
                                               ::Deepblue::LoggingHelper.called_from,
                                               "env=#{env}",
                                               "" ] if AFTER_OPTIMISTIC_LOCK_VALIDATOR_DEBUG_VERBOSE
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         next_actor.create( env )
       end
 
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if destroy was successful
       def destroy( env )
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         next_actor.destroy( env )
       end
 
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
       def update( env )
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         next_actor.update( env )
       end
 
       protected
 
-        # def log_event( env:, event: )
+        # def log_event( env:, event: ) if env.respond_to? :log_event
         #   actor = next_actor
         #   msg = "AfterOptimisticLockValidator.#{event}: env.curation_concern.class=#{env.curation_concern.class.name} next_actor=#{actor.class.name} env.attributes=#{ActiveSupport::JSON.encode env.attributes}"
         #   Deepblue::LoggingHelper.bold_debug( msg, lines: 2 )

--- a/app/actors/hyrax/actors/before_add_to_work_actor.rb
+++ b/app/actors/hyrax/actors/before_add_to_work_actor.rb
@@ -16,7 +16,7 @@ module Hyrax
                                                ::Deepblue::LoggingHelper.called_from,
                                                "env=#{env}",
                                                "" ] if BEFORE_ADD_TO_WORK_ACTOR_VERBOSE
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         work_ids = env.attributes.values_at( :in_works_ids )
         ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
                                            ::Deepblue::LoggingHelper.called_from,
@@ -30,7 +30,7 @@ module Hyrax
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if update was successful
       def update( env )
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         work_ids = env.attributes.values_at( :in_works_ids )
         Deepblue::LoggingHelper.bold_debug [ "BeforeAddToWorkActor.update: next_actor = #{next_actor.class.name}",
                                              "work_ids=#{work_ids}" ] if BEFORE_ADD_TO_WORK_ACTOR_VERBOSE

--- a/app/actors/hyrax/actors/before_model_actor.rb
+++ b/app/actors/hyrax/actors/before_model_actor.rb
@@ -14,7 +14,7 @@ module Hyrax
                                                ::Deepblue::LoggingHelper.called_from,
                                                "env=#{env}",
                                                "" ] if BEFORE_MODEL_ACTOR_DEBUG_VERBOSE
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         next_actor.create(env)
       end
 

--- a/app/actors/hyrax/actors/create_with_files_actor.rb
+++ b/app/actors/hyrax/actors/create_with_files_actor.rb
@@ -16,7 +16,7 @@ module Hyrax
                                                ::Deepblue::LoggingHelper.called_from,
                                                "env=#{env}",
                                                "" ] if CREATE_WITH_FILES_ACTOR_DEBUG_VERBOSE
-        env.log_event( next_actor: next_actor )
+        env.log_event( next_actor: next_actor ) if env.respond_to? :log_event
         uploaded_file_ids = filter_file_ids(env.attributes.delete(:uploaded_files))
         files = uploaded_files(uploaded_file_ids)
         validate_files(files, env) && next_actor.create(env) && attach_files(files, env)

--- a/app/actors/hyrax/actors/environment.rb
+++ b/app/actors/hyrax/actors/environment.rb
@@ -97,6 +97,7 @@ module Hyrax
       # @param [Ability] current_ability the authorizations of the acting user
       # @param [ActionController::Parameters] attributes user provided form attributes
       def initialize( curation_concern:, current_ability:, attributes:, action:, wants_format: )
+
         super( curation_concern,
                current_ability,
                EnvironmentAttributes.new( attributes.to_h.with_indifferent_access,

--- a/app/actors/hyrax/actors/interpret_visibility_actor.rb
+++ b/app/actors/hyrax/actors/interpret_visibility_actor.rb
@@ -1,13 +1,86 @@
-
-require File.join(Gem::Specification.find_by_name("hyrax").full_gem_path, "app/actors/hyrax/actors/interpret_visibility_actor.rb")
-
 module Hyrax
-
   module Actors
-
-    # monkey patch to allow embargo_release_date to be in the past
     class InterpretVisibilityActor < AbstractActor
+      class Intention
+        def initialize(attributes)
+          @attributes = attributes
+        end
 
+        # returns a copy of attributes with the necessary params removed
+        # If the lease or embargo is valid, or if they selected something besides lease
+        # or embargo, remove all the params.
+        def sanitize_params
+          if valid_lease?
+            sanitize_lease_params
+          elsif valid_embargo?
+            sanitize_embargo_params
+          elsif !wants_lease? && !wants_embargo?
+            sanitize_unrestricted_params
+          else
+            @attributes
+          end
+        end
+
+        def wants_lease?
+          visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE
+        end
+
+        def wants_embargo?
+          visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
+        end
+
+        def valid_lease?
+          wants_lease? && @attributes[:lease_expiration_date].present?
+        end
+
+        def valid_embargo?
+          wants_embargo? && @attributes[:embargo_release_date].present?
+        end
+
+        def lease_params
+          [:lease_expiration_date,
+           :visibility_during_lease,
+           :visibility_after_lease].map { |key| @attributes[key] }
+        end
+
+        def embargo_params
+          [:embargo_release_date,
+           :visibility_during_embargo,
+           :visibility_after_embargo].map { |key| @attributes[key] }
+        end
+
+        private
+
+          def sanitize_unrestricted_params
+            @attributes.except(:lease_expiration_date,
+                               :visibility_during_lease,
+                               :visibility_after_lease,
+                               :embargo_release_date,
+                               :visibility_during_embargo,
+                               :visibility_after_embargo)
+          end
+
+          def sanitize_embargo_params
+            @attributes.except(:visibility,
+                               :lease_expiration_date,
+                               :visibility_during_lease,
+                               :visibility_after_lease)
+          end
+
+          def sanitize_lease_params
+            @attributes.except(:visibility,
+                               :embargo_release_date,
+                               :visibility_during_embargo,
+                               :visibility_after_embargo)
+          end
+
+          def visibility
+            @attributes[:visibility]
+          end
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
       # @param [Hyrax::Actors::Environment] env
       # @return [Boolean] true if create was successful
       def create(env)
@@ -30,6 +103,7 @@ module Hyrax
         if env.respond_to? :clone_with_new
           new_env = env.clone_with_new( attributes:  attributes )
         else
+          # You should not be here if you are creating.
           new_env = Environment.new(env.curation_concern, env.current_ability, attributes)
         end
         validate(env, intention, attributes) && apply_visibility(new_env, intention) &&
@@ -37,6 +111,60 @@ module Hyrax
       end
 
       private
+
+        # Validate against selected AdminSet's PermissionTemplate (if any)
+        def validate(env, intention, attributes)
+          # If AdminSet was selected, look for its PermissionTemplate
+          template = PermissionTemplate.find_by!(source_id: attributes[:admin_set_id]) if attributes[:admin_set_id].present?
+
+          validate_lease(env, intention, template) &&
+            validate_release_type(env, intention, template) &&
+            validate_visibility(env, attributes, template) &&
+            validate_embargo(env, intention, attributes, template)
+        end
+
+        def apply_visibility(env, intention)
+          result = apply_lease(env, intention) && apply_embargo(env, intention)
+          env.curation_concern.visibility = env.attributes[:visibility] if env.attributes[:visibility]
+          result
+        end
+
+        # Validate that a lease is allowed by AdminSet's PermissionTemplate
+        def validate_lease(env, intention, template)
+          return true unless intention.wants_lease?
+
+          # Leases are only allowable if a template doesn't require a release period or have any specific visibility requirement
+          # (Note: permission template release/visibility options do not support leases)
+          unless template.present? && (template.release_period.present? || template.visibility.present?)
+            return true if intention.valid_lease?
+            env.curation_concern.errors.add(:visibility, 'When setting visibility to "lease" you must also specify lease expiration date.')
+            return false
+          end
+
+          env.curation_concern.errors.add(:visibility, 'Lease option is not allowed by permission template for selected AdminSet.')
+          false
+        end
+
+        # Validate the selected release settings against template, checking for when embargoes/leases are not allowed
+        def validate_release_type(env, intention, template)
+          # It's valid as long as embargo is not specified when a template requires no release delays
+          return true unless intention.wants_embargo? && template.present? && template.release_no_delay?
+
+          env.curation_concern.errors.add(:visibility, 'Visibility specified does not match permission template "no release delay" requirement for selected AdminSet.')
+          false
+        end
+
+        # Validate visibility complies with AdminSet template requirements
+        def validate_visibility(env, attributes, template)
+          # NOTE: For embargo/lease, attributes[:visibility] will be nil (see sanitize_params), so visibility will be validated as part of embargo/lease
+          return true if attributes[:visibility].blank?
+
+          # Validate against template's visibility requirements
+          return true if validate_template_visibility(attributes[:visibility], template)
+
+          env.curation_concern.errors.add(:visibility, 'Visibility specified does not match permission template visibility requirement for selected AdminSet.')
+          false
+        end
 
         # When specified, validate embargo is a future date that complies with AdminSet template requirements (if any)
         def validate_embargo(env, intention, attributes, template)
@@ -68,8 +196,63 @@ module Hyrax
           false
         end
 
+        # Validate an date attribute is in the future
+        def valid_future_date?(env, date, attribute_name: :embargo_release_date)
+          return true if date.present? && date.future?
+
+          env.curation_concern.errors.add(attribute_name, "Must be a future date.")
+          false
+        end
+
+        # Validate an embargo date against permission template restrictions
+        def valid_template_embargo_date?(env, date, template)
+          return true if template.blank?
+
+          # Validate against template's release_date requirements
+          return true if template.valid_release_date?(date)
+
+          env.curation_concern.errors.add(:embargo_release_date, "Release date specified does not match permission template release requirements for selected AdminSet.")
+          false
+        end
+
+        # Validate the post-embargo visibility against permission template requirements (if any)
+        def valid_template_visibility_after_embargo?(env, attributes, template)
+          # Validate against template's visibility requirements
+          return true if validate_template_visibility(attributes[:visibility_after_embargo], template)
+
+          env.curation_concern.errors.add(:visibility_after_embargo, "Visibility after embargo does not match permission template visibility requirements for selected AdminSet.")
+          false
+        end
+
+        # Validate that a given visibility value satisfies template requirements
+        def validate_template_visibility(visibility, template)
+          return true if template.blank?
+
+          template.valid_visibility?(visibility)
+        end
+
+        # Parse date from string. Returns nil if date_string is not a valid date
+        def parse_date(date_string)
+          datetime = Time.zone.parse(date_string) if date_string.present?
+          return datetime.to_date unless datetime.nil?
+          nil
+        end
+
+        # If they want a lease, we can assume it's valid
+        def apply_lease(env, intention)
+          return true unless intention.wants_lease?
+          env.curation_concern.apply_lease(*intention.lease_params)
+          return unless env.curation_concern.lease
+          env.curation_concern.lease.save # see https://github.com/samvera/hydra-head/issues/226
+        end
+
+        # If they want an embargo, we can assume it's valid
+        def apply_embargo(env, intention)
+          return true unless intention.wants_embargo?
+          env.curation_concern.apply_embargo(*intention.embargo_params)
+          return unless env.curation_concern.embargo
+          env.curation_concern.embargo.save # see https://github.com/samvera/hydra-head/issues/226
+        end
     end
-
   end
-
 end

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -1,0 +1,144 @@
+# Reference
+# https://github.com/samvera/hyrax/blob/master/app/controllers/concerns/hyrax/works_controller_behavior.rb
+# https://github.com/samvera/hyrax/blob/master/app/controllers/hyrax/uploads_controller.rb
+# https://github.com/leaf-research-technologies/leaf_addons/blob/master/lib/generators/leaf_addons/templates/lib/importer/factory/object_factory.rb
+# https://github.com/leaf-research-technologies/leaf_addons/blob/master/lib/generators/leaf_addons/templates/lib/importer/files_parser.rb
+# https://github.com/leaf-research-technologies/leaf_addons/blob/9643b649df513e404c96ba5b9285d83abc4b2c9a/lib/generators/leaf_addons/templates/lib/importer/factory/base_factory.rb
+
+require_relative "../../../../actors/hyrax/actors/environment"
+
+module Integrator
+  module Hyrax
+    module WorksBehavior
+      extend ActiveSupport::Concern
+
+      def upload_files
+        @file_ids = []
+        @files.each do |file|
+          u = ::Hyrax::UploadedFile.new
+          @current_user = User.batch_user unless @current_user.present?
+          u.user_id = @current_user.id unless @current_user.nil?
+          u.file = ::CarrierWave::SanitizedFile.new(file)
+          u.save
+          @file_ids << u.id
+        end
+      end
+
+      def add_work
+        @object = find_work if @object.blank?
+        if @object
+          update_work
+        else
+          create_work
+        end
+      end
+
+      def find_work_by_query(work_id = params[:id])
+        model = find_work_klass(work_id)
+        return nil if model.blank?
+        @work_klass = model.constantize
+        @object = find_work(work_id)
+      end
+
+      def find_work(work_id = params[:id])
+        # params[:id] = SecureRandom.uuid unless params[:id].present?
+        return find_work_by_id(work_id) if work_id
+      end
+
+      def find_work_by_id(work_id = params[:id])
+        @work_klass.find(work_id)
+      rescue ActiveFedora::ActiveFedoraError
+        nil
+      end
+
+      def update_work
+        raise "Object doesn't exist" unless @object
+        work_actor.update(environment(update_attributes))
+      end
+
+      def create_work
+        attrs = create_attributes
+        @object = @work_klass.new
+
+        # See what the attrs are here.  Perhaps there is something missing here.
+        work_actor.create(environment(attrs))
+      end
+
+      def create_attributes
+        transform_attributes
+      end
+
+      def update_attributes
+        transform_attributes.except(:id, 'id')
+      end
+
+      private
+        def set_work_klass
+          # Transform name of model to match across name variations
+          work_models = WillowSword.config.work_models
+          if work_models.kind_of?(Array)
+            work_models = work_models.map { |m| [m, m] }.to_h
+          end
+          work_models.transform_keys!{ |k| k.underscore.gsub('_', ' ').gsub('-', ' ').downcase }
+          # Match with header first, then resource type and finally pick one from list
+          hyrax_work_model = @headers.fetch(:hyrax_work_model, nil)
+          if hyrax_work_model and work_models.include?(hyrax_work_model)
+            # Read the class from the header
+            @work_klass = work_models[hyrax_work_model].constantize
+          elsif @resource_type and work_models.include?(@resource_type)
+            # Set the class based on the resource type
+            @work_klass = work_models[@resource_type].constantize
+          else
+            # Chooose the first class from the config
+            @work_klass = work_models[work_models.keys.first].constantize
+          end
+        end
+
+        # @param [Hash] attrs the attributes to put in the environment
+        # @return [Hyrax::Actors::Environment]
+        def environment(attrs)
+          # Set Hyrax.config.batch_user_key
+          @current_user = User.batch_user unless @current_user.present?
+          ::Hyrax::Actors::EnvironmentEnhanced.new(curation_concern: @object, current_ability: Ability.new(@current_user), 
+                                                   attributes:attrs, action:"create", wants_format:nil)
+        end
+
+        def work_actor
+          ::Hyrax::CurationConcern.actor
+        end
+
+        # Override if we need to map the attributes from the parser in
+        # a way that is compatible with how the factory needs them.
+        def transform_attributes
+          # TODO: attributes are strings and not symbols
+          if WillowSword.config.allow_only_permitted_attributes
+           @attributes.slice(*permitted_attributes).merge(file_attributes)
+          else
+           @attributes.merge(file_attributes)
+          end
+        end
+
+        def file_attributes
+          @file_ids.present? ? { uploaded_files: @file_ids } : {}
+        end
+
+        def permitted_attributes
+          @work_klass.properties.keys.map(&:to_sym) + [:id, :edit_users, :edit_groups, :read_groups, :visibility]
+        end
+
+        def find_work_klass(work_id)
+          model = nil
+          blacklight_config = Blacklight::Configuration.new
+          search_builder = Blacklight::SearchBuilder.new([], blacklight_config)
+          search_builder.merge(fl: 'id, has_model_ssim')
+          search_builder.merge(fq: "{!raw f=id}#{work_id}")
+          repository = Blacklight::Solr::Repository.new(blacklight_config)
+          response = repository.search(search_builder.query)
+          if response.dig('response', 'numFound') == 1
+            model = response.dig('response', 'docs')[0]['has_model_ssim'][0]
+          end
+          model
+        end
+    end
+  end
+end

--- a/app/services/willow_sword/crosswalk_from_dc_data.rb
+++ b/app/services/willow_sword/crosswalk_from_dc_data.rb
@@ -1,0 +1,75 @@
+module WillowSword
+  class CrosswalkFromDcData
+    attr_reader :dc, :metadata, :model, :mapped_metadata, :files_metadata, :terms, :translated_terms, :singular
+    def initialize(src_file, headers)
+      @src_file = src_file
+      @headers = headers
+      @dc = nil
+      @model = nil
+      @metadata = {}
+      @mapped_metadata = {}
+      @files_metadata = []
+    end
+
+    def terms
+      %w(subject_discipline rights_license authoremail methodology abstract 
+        accessRights accrualMethod accrualPeriodicity
+        accrualPolicy alternative audience available bibliographicCitation
+        conformsTo contributor coverage created creator date dateAccepted
+        dateCopyrighted dateSubmitted description educationLevel extent
+        format hasFormat hasPart hasVersion identifier instructionalMethod
+        isFormatOf isPartOf isReferencedBy isReplacedBy isRequiredBy issued
+        isVersionOf language license mediator medium modified provenance
+        publisher references relation replaces requires rights rightsHolder
+        source spatial subject tableOfContents temporal title type valid)
+    end
+
+    def translated_terms
+      {
+        'created' =>'date_created',
+        'rights' => 'rights_statement',
+        'relation' => 'related_url',
+        'type' => 'resource_type'
+      }
+    end
+
+    def singular
+      %w(rights authoremail rights_license)
+    end
+
+    def map_xml
+      parse_dc
+      @mapped_metadata = @metadata
+      assign_model if @metadata.any?
+    end
+
+    def parse_dc
+      return @metadata unless @src_file.present?
+      return @metadata unless File.exist? @src_file
+      f = File.open(@src_file)
+      doc = Nokogiri::XML(f)
+      # doc = Nokogiri::XML(@xml_metadata)
+      doc.remove_namespaces!
+      terms.each do |term|
+        values = []
+        doc.xpath("//#{term}").each do |t|
+          values << t.text if t.text.present?
+        end
+        key = translated_terms.include?(term) ? translated_terms[term] : term
+        values = values.first if values.present? && singular.include?(term)
+        @metadata[key.to_sym] = values unless values.blank?
+      end
+      f.close
+    end
+
+    def assign_model
+      unless @metadata.fetch(:resource_type, nil).blank?
+        @model = Array(@metadata[:resource_type]).map {
+          |t| t.underscore.gsub('_', ' ').gsub('-', ' ').downcase
+        }.first
+      end
+    end
+
+  end
+end
+

--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -1,0 +1,28 @@
+WillowSword.setup do |config|
+  # The title used by the sword server, in the service document
+  config.title = 'Deep Blue Data Sword V2 server'
+  # If you do not want to use collections in Sword, it will use this as a default collection
+  config.default_collection = {id: '5425k9692jose', title: ['To test sword deposits.']}
+  # The name of the model for retreiving collections (based on Hyrax integration)
+  config.collection_models = ['Collection']
+  # The work models supported by Sword (based on Hyrax integration)
+  config.work_models = ['DataSet']
+  # The fileset model supported by Sword (based on Hyrax integration)
+  config.file_set_models = ['FileSet']
+  # Remove all parameters that are not part of the model's permitted attributes
+  config.allow_only_permitted_attributes = true
+  # Default visibility for works
+  config.default_visibility = 'open'
+  # Metadata filename in payload
+  config.metadata_filename = 'metadata.xml'
+  # XML crosswalk for creating a work
+  config.xw_from_xml_for_work = WillowSword::CrosswalkFromDcData
+  # XML crosswalk for creating a fileset
+  config.xw_from_xml_for_fileset = WillowSword::CrosswalkFromDc
+  # XML crosswalk when requesting a work
+  config.xw_to_xml_for_work = WillowSword::CrosswalkWorkToDc
+  # XML crosswalk when requesting a fileet
+  config.xw_to_xml_for_fileset = WillowSword::CrosswalkFilesetToDc
+  # Authorize Sword requests using Api-key header
+  config.authorize_request = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,8 @@ Rails.application.routes.draw do
     end
   end
 
+  mount WillowSword::Engine => '/sword'
+
   # Permissions routes
   namespace :hyrax, path: :concern do
   resources :permissions, only: [] do

--- a/db/migrate/20210622174656_add_api_key_to_users.rb
+++ b/db/migrate/20210622174656_add_api_key_to_users.rb
@@ -1,0 +1,6 @@
+class AddAPIKeyToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :api_key, :string
+    add_index :users, :api_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_141248) do
+ActiveRecord::Schema.define(version: 2021_06_22_174656) do
 
   create_table "ahoy_condensed_events", force: :cascade do |t|
     t.string "name"
@@ -302,7 +302,7 @@ ActiveRecord::Schema.define(version: 2020_10_28_141248) do
     t.string "namespace", default: "default", null: false
     t.string "template", null: false
     t.text "counters"
-    t.integer "seq", default: 0
+    t.integer "seq", limit: 8, default: 0
     t.binary "rand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -630,6 +630,8 @@ ActiveRecord::Schema.define(version: 2020_10_28_141248) do
     t.string "invited_by_type"
     t.integer "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.string "api_key"
+    t.index ["api_key"], name: "index_users_on_api_key"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true


### PR DESCRIPTION
Here are some things to keep in mind:

1.  I made a change to the Gemfile.  After speaking to cottagelabs, they told me to use the develop branch of willow_sword ( this branch gives us the ability to change the kind of dc metadata processed by the gem), so this is one change to the Gemfile. The other is that in my dev environment I can't use the mysql gem, so I have commented this out.  @fritzfreiheit if you could, after merging this PR, do a fresh bundle install after uncommenting out that line.  This will obviously affect the Gemfile.lock file.  Then you can send a PR with the correct Gemfile and Gemfile.lock.

2.  I think there is a new migration that will have to be run in production for us to use token authentication.  The instructions for that are here:

https://github.com/CottageLabs/willow_sword/wiki/Enabling-Authorization-In-Willow-Sword

Thanks!
-Jose