### PR TITLE
during sword put item in workflow and in collection requested.

### DIFF
--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -1,0 +1,55 @@
+module Hyrax
+  module Actors
+    # Ensures that the default AdminSet id is set if this form doesn't have
+    # an admin_set_id provided. This should come before the
+    # Hyrax::Actors::InitializeWorkflowActor, so that the correct
+    # workflow can be kicked off.
+    #
+    # @note Creates AdminSet, Hyrax::PermissionTemplate, Sipity::Workflow (with activation)
+    class DefaultAdminSetActor < Hyrax::Actors::AbstractActor
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+        ensure_admin_set_attribute!(env)
+        next_actor.create(env)
+      end
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if update was successful
+      def update(env)
+        ensure_admin_set_attribute!(env)
+        next_actor.update(env)
+      end
+
+      private
+
+        def ensure_admin_set_attribute!(env)
+          if env.attributes[:admin_set_id].present?
+            ensure_permission_template!(admin_set_id: env.attributes[:admin_set_id])
+          elsif env.curation_concern.admin_set_id.present?
+            env.attributes[:admin_set_id] = env.curation_concern.admin_set_id
+            ensure_permission_template!(admin_set_id: env.attributes[:admin_set_id])
+          else
+            AdminSet.find_each do |admin_set|
+              unless admin_set.id.eql? ("admin_set/default")
+                env.attributes[:admin_set_id] = admin_set.id
+              end
+            end
+          end
+        end
+
+        def ensure_permission_template!(admin_set_id:)
+          Hyrax::PermissionTemplate.find_by(source_id: admin_set_id) || create_permission_template!(source_id: admin_set_id)
+        end
+
+        def default_admin_set_id
+          AdminSet.find_or_create_default_admin_set_id
+        end
+
+        # Creates a Hyrax::PermissionTemplate for the given AdminSet
+        def create_permission_template!(source_id:)
+          Hyrax::PermissionTemplate.create!(source_id: source_id)
+        end
+    end
+  end
+end

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -13,14 +13,22 @@ module Integrator
       extend ActiveSupport::Concern
 
       def upload_files
+        return if @files.blank?
         @file_ids = []
+        @uploaded_files = {}
         @files.each do |file|
           u = ::Hyrax::UploadedFile.new
           @current_user = User.batch_user unless @current_user.present?
           u.user_id = @current_user.id unless @current_user.nil?
           u.file = ::CarrierWave::SanitizedFile.new(file)
           u.save
-          @file_ids << u.id
+          chosen_file = @files_attributes.select{ |fa| File.basename(fa['filepath']) == File.basename(file) }
+          if chosen_file.any?
+            chosen_file[0]['uploaded_file'] = u
+            @uploaded_files[File.basename(file)] = chosen_file[0]
+          else
+            @file_ids << u.id
+          end
         end
       end
 
@@ -30,6 +38,13 @@ module Integrator
           update_work
         else
           create_work
+        end
+      end
+
+      def upload_files_with_attributes
+        return if @uploaded_files.blank?
+        @uploaded_files.each do |file_name, uploaded_file|
+          create_file_set_with_attributes(uploaded_file)
         end
       end
 
@@ -58,21 +73,28 @@ module Integrator
 
       def create_work
         attrs = create_attributes
+        #the object 
         @object = @work_klass.new
-
-        # See what the attrs are here.  Perhaps there is something missing here.
         work_actor.create(environment(attrs))
-      end
 
-      def create_attributes
-        transform_attributes
-      end
-
-      def update_attributes
-        transform_attributes.except(:id, 'id')
+        collection_id = params["collection_id"]
+        unless collection_id.blank?
+          collection_id =  WillowSword.config.default_collection[:id] if collection_id.eql? ("default")
+          collection = Collection.find (collection_id)
+          @object.member_of_collections << collection
+          @object.save!
+        end
       end
 
       private
+        def create_attributes
+          transform_attributes
+        end
+
+        def update_attributes
+          transform_attributes.except(:id, 'id')
+        end
+
         def set_work_klass
           # Transform name of model to match across name variations
           work_models = WillowSword.config.work_models
@@ -99,7 +121,8 @@ module Integrator
         def environment(attrs)
           # Set Hyrax.config.batch_user_key
           @current_user = User.batch_user unless @current_user.present?
-          ::Hyrax::Actors::EnvironmentEnhanced.new(curation_concern: @object, current_ability: Ability.new(@current_user), 
+          #::Hyrax::Actors::EnvironmentEnhanced.new(@object, Ability.new(@current_user), attrs)
+          ::Hyrax::Actors::EnvironmentEnhanced.new(curation_concern: @object, current_ability: Ability.new(@current_user),
                                                    attributes:attrs, action:"create", wants_format:nil)
         end
 
@@ -111,6 +134,7 @@ module Integrator
         # a way that is compatible with how the factory needs them.
         def transform_attributes
           # TODO: attributes are strings and not symbols
+          @attributes['visibility'] = WillowSword.config.default_visibility if @attributes.fetch('visibility', nil).blank?
           if WillowSword.config.allow_only_permitted_attributes
            @attributes.slice(*permitted_attributes).merge(file_attributes)
           else
@@ -138,6 +162,47 @@ module Integrator
             model = response.dig('response', 'docs')[0]['has_model_ssim'][0]
           end
           model
+        end
+
+        def create_file_set_with_attributes(file_attributes)
+          @file_set_klass = WillowSword.config.file_set_models.first.constantize
+          file_set = @file_set_klass.create
+          @current_user = User.batch_user unless @current_user.present?
+          actor = file_set_actor.new(file_set, @current_user)
+          actor.file_set.permissions_attributes = @object.permissions.map(&:to_hash)
+          # Add file
+          if file_attributes.fetch('uploaded_file', nil)
+            actor.create_content(file_attributes['uploaded_file'])
+          end
+          title = Array(file_attributes.dig('mapped_metadata', 'file_name'))
+          unless title.any?
+            filepath = file_attributes.fetch('filepath', nil)
+            title = [File.basename(filepath)] unless filepath.blank?
+          end
+          actor.file_set.title = title
+          # update_metadata
+          unless file_attributes['mapped_metadata'].blank?
+            chosen_attributes = file_set_attributes(file_attributes['mapped_metadata'])
+            actor.file_set.update(chosen_attributes)
+            actor.file_set.save!
+          end
+          actor.attach_to_work(@object) if @object
+        end
+
+        def file_set_attributes(attributes)
+          if WillowSword.config.allow_only_permitted_attributes
+            attributes.slice(*permitted_file_attributes).except(:id, 'id')
+          else
+            attributes.except(:id, 'id')
+          end
+        end
+
+        def file_set_actor
+          ::Hyrax::Actors::FileSetActor
+        end
+
+        def permitted_file_attributes
+          @file_set_klass.properties.keys.map(&:to_sym) + [:id, :edit_users, :edit_groups, :read_groups, :visibility]
         end
     end
   end

--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -5,7 +5,8 @@ WillowSword.setup do |config|
   # The title used by the sword server, in the service document
   config.title = 'Deep Blue Data Sword V2 server'
   # If you do not want to use collections in Sword, it will use this as a default collection
-  config.default_collection = {id: '5425k9692jose', title: ['To test sword deposits.']}
+  # This is the default collection in production
+  config.default_collection = {id: 'bk128999s', title: ['University of Michigan Museum of Zoology']}
   # The name of the model for retreiving collections (based on Hyrax integration)
   config.collection_models = ['Collection']
   # The work models supported by Sword (based on Hyrax integration)


### PR DESCRIPTION
For sword release these are important notes to have in PR for future reference.

Things involved in this PR that might be forgotten.

1.  We are using the "develop" branch of the cottage lab sword implementation because it has a way to configure 
    the dc data in config/initializers/willow_sword.rb.  We needed this because Deep Blue Data has some very specific
    metadata that was not in the default out of the box configuration.

2.  When using the out of the box sword to ingest, the works where not being put in a workflow.  This was because
    in this file app/actors/hyrax/actors/default_admin_set_actor.rb ( which before this PR was not subclassed ) if 
    there is no admin set associated with the work, the work was put in the default admin set, which is configured
    to have a one-step-deposit workflow.  This file changed to put the work in our other admin set ( we have two: the
    default, and the one we use for Data, which is setup to use the mediated-deposit.  Here is the specific code that changed in this file:

    ```
    AdminSet.find_each do |admin_set|
      unless admin_set.id.eql? ("admin_set/default")
        env.attributes[:admin_set_id] = admin_set.id
      end
    end```

3.  This file needed to be subclassed from the cottage labs sword gem: app/controllers/concerns/integrator/hyrax/works_behavior.rb.  Remember that if we ever change the branch we are using, we may need to change this file.
    There were two reasons for this:

    (1)  to use ::Hyrax::Actors::EnvironmentEnhanced, which is what we now use for Data, rather than:
         ::Hyrax::Actors::Environment

    (2)  When depositing a work  to a specific collection, the work was not being placed in the collection.  The developer
         at Cottage Lab told me that this is something not done by their gem.  So there is code now, so that when a collection_id is 
         passed in ( http://localhost:3000/data/sword/collections/5425k9692/works OR http://localhost:3000/data/sword/collections/default/works ),
         the work is placed in the collection.  This is the code that does that:

         collection_id = params["collection_id"]
         unless collection_id.blank?
           collection_id =  WillowSword.config.default_collection[:id] if collection_id.eql? ("default")
           collection = Collection.find (collection_id)
           @object.member_of_collections << collection
           @object.save!
         end

4.  The default collection was set in this file: config/initializers/willow_sword.rb

config.default_collection = {id: 'bk128999s', title: ['University of Michigan Museum of Zoology']}
