### PR TITLE
adding Save as Draft functionality.

### DIFF
--- a/app/actors/hyrax/actors/initialize_workflow_actor.rb
+++ b/app/actors/hyrax/actors/initialize_workflow_actor.rb
@@ -1,0 +1,51 @@
+module Hyrax
+  module Actors
+    # Responsible for generating the workflow for the given curation_concern.
+    # Done through direct collaboration with the configured Hyrax::Actors::InitializeWorkflowActor.workflow_factory
+    #
+    # @see Hyrax::Actors::InitializeWorkflowActor.workflow_factory
+    # @see Hyrax::Workflow::WorkflowFactory for default workflow factory
+    class InitializeWorkflowActor < AbstractActor
+      class_attribute :workflow_factory
+      self.workflow_factory = ::Hyrax::Workflow::WorkflowFactory
+
+      # @param [Hyrax::Actors::Environment] env
+      # @return [Boolean] true if create was successful
+      def create(env)
+          next_actor.create(env) && create_workflow(env)
+      end
+
+      def update(env)
+        # A work that was a draft is now being published ( the admin set is no longer the Draft Admin Set ), 
+        # so you need to put it in the mediated workflow.
+        if ( env.curation_concern.to_sipity_entity&.workflow_state_name.eql?("draft")  && env.curation_concern.admin_set_id != ::Deepblue::DraftAdminSetService.draft_admin_set_id )
+          work_id = env.curation_concern.id
+
+          #Get the entity
+          entity = env.curation_concern.to_sipity_entity
+          wf = env.curation_concern.active_workflow 
+
+          # initiate the workflow state
+          action_name = "pending_review"
+
+          action = Sipity::WorkflowAction.find_or_create_by!( workflow: wf, name: action_name )
+          wf_state = Sipity::WorkflowState.find_or_create_by!( workflow: wf, name: action_name )
+
+          entity.update!( workflow: wf, workflow_state_id: action.id, workflow_state: wf_state )
+
+          next_actor.create(env)
+        else
+          super
+        end
+      end
+
+
+      private
+
+        # @return [TrueClass]
+        def create_workflow(env)
+          workflow_factory.create(env.curation_concern, env.attributes, env.user)
+        end
+    end
+  end
+end

--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -83,7 +83,7 @@ export default class SaveWorkControl {
     }
     this.requiredFields = new RequiredFields(this.form, () => this.formStateChanged())
     this.uploads = new UploadedFiles(this.form, () => this.formStateChanged())
-    this.saveButton = this.element.find(':submit')
+    this.saveButton = this.element.find('#with_files_submit')
     this.depositAgreement = new DepositAgreement(this.form, () => this.formStateChanged())
     this.requiredMetadata = new ChecklistItem(this.element.find('#required-metadata'))
     this.requiredFiles = new ChecklistItem(this.element.find('#required-files'))

--- a/app/services/deepblue/draft_admin_set_service.rb
+++ b/app/services/deepblue/draft_admin_set_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Deepblue
+ 
+  module DraftAdminSetService
+
+    @@_setup_ran = false
+    @@_setup_failed = false
+
+    mattr_accessor :draft_admin_set_title, default: "Draft works Admin Set"
+
+    def self.draft_admin_set_id
+      @@draft_admin_set_id ||= draft_admin_set_id_init
+    end
+
+    def self.draft_admin_set
+      AdminSet.find draft_admin_set_id
+    end
+
+    def self.draft_admin_set_id_init
+      draft_admin_set_id = ""
+      AdminSet.find_each do |admin_set|
+        if admin_set.title.first.eql? draft_admin_set_title 
+          draft_admin_set_id = admin_set.id
+        end
+      end
+      draft_admin_set_id
+    end
+
+
+    def self.setup
+      return if @@_setup_ran == true
+      @@_setup_ran = true
+      begin
+        yield self
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        @@_setup_failed = true
+      end
+    end
+
+  end
+
+end

--- a/app/services/deepblue/work_view_content_service.rb.backup
+++ b/app/services/deepblue/work_view_content_service.rb.backup
@@ -1,0 +1,326 @@
+# frozen_string_literal: true
+
+require_relative './initialization_constants'
+
+module Deepblue
+
+  module WorkViewContentService
+
+    include ::Deepblue::InitializationConstants
+
+    @@_setup_ran = false
+
+    mattr_accessor :interpolation_helper_debug_verbose, default: false
+    mattr_accessor :static_content_controller_behavior_verbose, default: false
+    mattr_accessor :static_content_cache_debug_verbose, default: false
+    mattr_accessor :work_view_documentation_controller_debug_verbose, default: false
+    mattr_accessor :work_view_content_service_debug_verbose, default: false
+    mattr_accessor :work_view_content_service_email_templates_debug_verbose, default: false
+    mattr_accessor :work_view_content_service_i18n_templates_debug_verbose, default: false
+    mattr_accessor :work_view_content_service_view_templates_debug_verbose, default: false
+
+    mattr_accessor :documentation_collection_title,   default: "DBDDocumentationCollection"
+    mattr_accessor :documentation_work_title_prefix,  default: "DBDDoc-"
+    mattr_accessor :documentation_email_title_prefix, default: "DBDEmail-"
+    mattr_accessor :documentation_i18n_title_prefix,  default: "DBDI18n-"
+    mattr_accessor :documentation_view_title_prefix,  default: "DBDView-"
+    mattr_accessor :export_documentation_path,        default: '/tmp/documentation_export'
+
+    mattr_accessor :static_content_controller_behavior_menu_verbose, default: false
+    mattr_accessor :static_content_enable_cache,                     default: true
+    mattr_accessor :static_content_interpolation_pattern,            default: nil
+    mattr_accessor :static_controller_redirect_to_work_view_content, default: false
+
+    mattr_accessor :draft_admin_set_title, default: "Draft works Admin Set"
+
+
+    def self.setup
+      yield self if @@_setup_ran == false
+      @@_setup_ran = true
+    end
+
+    def self.draft_admin_set_id
+      @@draft_admin_set_id ||= draft_admin_set_id_init
+    end
+
+    def self.draft_admin_set
+      AdminSet.find draft_admin_set_id
+    end
+
+    def self.draft_admin_set_id_init
+      draft_admin_set_id = ""
+      AdminSet.find_each do |admin_set|
+        if admin_set.title.first.eql? draft_admin_set_title 
+          draft_admin_set_id = admin_set.id
+        end
+      end
+      draft_admin_set_id
+    end
+
+
+    def self.content_documentation_collection_id
+      @@static_content_documentation_collection_id ||= content_documentation_collection_id_init
+    end
+
+    def self.content_documentation_collection_id_init
+      title = documentation_collection_title
+      solr_query = "+generic_type_sim:Collection AND +title_tesim:#{title}"
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "title=#{title}",
+                                             "solr_query=#{solr_query}",
+                                             "" ], bold_puts: true if work_view_content_service_debug_verbose
+      results = ::ActiveFedora::SolrService.query( solr_query, rows: 10 )
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "results.class.name=#{results.class.name}",
+                                             "results=#{results}",
+                                             "" ], bold_puts: true if work_view_content_service_debug_verbose
+      return nil unless results.present?
+      return result.id if results.is_a? Collection
+      result = results[0] if results
+      return result.id
+    end
+
+    def self.content_documentation_collection
+      id = content_documentation_collection_id
+      collection = content_find_by_id( id: id )
+      return collection
+    rescue Exception => ignore
+      return nil
+    end
+
+    def self.content_find_by_id( id:, raise_error: false )
+      return nil if id.blank?
+      content = ::PersistHelper.find( id )
+      return content
+    rescue Ldp::Gone
+      raise if raise_error
+      return nil
+    rescue ActiveFedora::ObjectNotFoundError
+      raise if raise_error
+      return nil
+    end
+
+    def self.content_read_file( file_set: )
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "file_set=#{file_set.id}",
+                                             "" ] if work_view_content_service_debug_verbose
+      file = file_set.files_to_file
+      if file.nil?
+        return nil
+      else
+        source_uri = file.uri.value
+        ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                               ::Deepblue::LoggingHelper.called_from,
+                                               "source_uri=#{source_uri}",
+                                               "" ] if work_view_content_service_debug_verbose
+        str = open( source_uri, "r:UTF-8" ) { |io| io.read }
+        ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                               ::Deepblue::LoggingHelper.called_from,
+                                               "str.encoding=#{str.encoding}",
+                                               "" ] if work_view_content_service_debug_verbose
+        return str
+      end
+      return nil
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      msg = "WorkViewContentService.static_content_read_file #{source_uri} - #{e.class}: #{e.message} at #{e.backtrace[0]}"
+      Rails.logger.error msg
+      return nil
+    end
+
+    def self.load_email_templates( debug_verbose: work_view_content_service_email_templates_debug_verbose ||
+                                    work_view_content_service_debug_verbose )
+      # puts "Current I18n.backend=#{I18n.backend}"
+      # puts "DeepBlueDocs::Application.config.i18n_backend=#{DeepBlueDocs::Application.config.i18n_backend}"
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "" ] if debug_verbose
+      return unless Dir.exist?( './data/' ) # skip this unless in real server environment (./data/ does not exist for moku build environment)
+      docCollection = content_documentation_collection
+      return unless docCollection.present?
+      prefix = documentation_email_title_prefix
+      keys_updated = []
+      docCollection.member_works.each do |work|
+        ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                               ::Deepblue::LoggingHelper.called_from,
+                                               "prefix=#{prefix}",
+                                               "work.title.first=#{work.title.first}",
+                                               "" ] if debug_verbose
+        if work.title.first.starts_with? prefix
+          work.file_sets.each do |fs|
+            file_name = fs.label
+            if file_name =~ /^(.+)\.txt$/i
+              key = Regexp.last_match(1)
+              value = content_read_file( file_set: fs )
+              keys_updated << load_templates_store( key: key, value: value )
+            elsif file_name =~ /^(.+)\.html$/i
+              key = "#{Regexp.last_match(1)}_html"
+              value = content_read_file( file_set: fs )
+              keys_updated << load_templates_store( key: key, value: value )
+            end
+          end
+        end
+      end
+      load_templates_store( key: "hyrax.email.templates.keys_loaded",
+                           value: keys_updated.join("; ") )
+      load_templates_store( key: "hyrax.email.templates.keys_loaded_html",
+                           value: "<li>#{keys_updated.join("</li>\n<li>")}</li>" )
+      keys_updated << "hyrax.email.templates.keys_loaded"
+      keys_updated << "hyrax.email.templates.keys_loaded_html"
+      keys_updated << load_templates_store( key: "hyrax.email.templates.loaded", value: "true" )
+      keys_updated << load_templates_store( key: "hyrax.email.templates.last_loaded", value: DateTime.now.to_s )
+      if debug_verbose
+        keys_updated.each do |key|
+          options = EmailHelper.template_default_options( curation_concern: nil )
+          ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                                 ::Deepblue::LoggingHelper.called_from,
+                                                 "key=#{key}",
+                                                 I18n.t( key, **options ),
+                                                 "" ] if debug_verbose
+        end
+      end
+    end
+
+    def self.load_templates_store( key:,
+                                   value:,
+                                   escape: false,
+                                   locale: "en",
+                                   debug_verbose: work_view_content_service_email_templates_debug_verbose ||
+                                     work_view_content_service_debug_verbose )
+
+      I18n.backend.store_translations( locale, { key => value }, :escape => escape )
+      I18n.backend.store_translations( locale, { key.to_sym => value }, :escape => escape )
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "I18n.t( '#{key}' )='#{I18n.t( key )}'",
+                                             "" ], bold_puts: debug_verbose if debug_verbose
+      return key
+    end
+
+    def self.load_i18n_templates( debug_verbose: work_view_content_service_view_templates_debug_verbose ||
+                                    work_view_content_service_debug_verbose )
+
+      load_i18n_templates_using_prefix( prefix: documentation_i18n_title_prefix,
+                                        key_prefix: "hyrax.i18n.templates",
+                                        debug_verbose: debug_verbose )
+    end
+
+    def self.load_view_templates( debug_verbose: work_view_content_service_view_templates_debug_verbose ||
+                                    work_view_content_service_debug_verbose )
+
+      load_i18n_templates_using_prefix( prefix: documentation_view_title_prefix,
+                                        key_prefix: "hyrax.view.templates",
+                                        debug_verbose: debug_verbose )
+    end
+
+    def self.load_i18n_templates_using_prefix( prefix:,
+                                               key_prefix:,
+                                               debug_verbose: work_view_content_service_debug_verbose )
+
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "prefix=#{prefix}",
+                                             "key_prefix=#{key_prefix}",
+                                             "" ], bold_puts: debug_verbose if debug_verbose
+
+      return unless Dir.exist?( './data/' ) # skip this unless in real server environment (./data/ does not exist for moku build environment)
+      docCollection = content_documentation_collection
+      return unless docCollection.present?
+      docCollection.member_works.each do |work|
+        ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                               ::Deepblue::LoggingHelper.called_from,
+                                               "prefix=#{prefix}",
+                                               "work.title.first=#{work.title.first}",
+                                               "" ], bold_puts: debug_verbose if debug_verbose
+        if work.title.first.starts_with? prefix
+          work.file_sets.each do |fs|
+            file_name = fs.label
+            if file_name =~ /^(.+)\.yml$/i
+              key = Regexp.last_match(1)
+              value = content_read_file( file_set: fs )
+              load_i18n_templates_process( key: key, value: value, debug_verbose: debug_verbose )
+            elsif file_name =~ /^(.+)\.txt$/i
+              key = Regexp.last_match(1)
+              value = content_read_file( file_set: fs )
+              locale = "en" # TODO: possibly store the locale in description
+              ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                                     ::Deepblue::LoggingHelper.called_from,
+                                                     "key=#{key}",
+                                                     "value=#{value}",
+                                                     "locale=#{locale}",
+                                                     "" ], bold_puts: debug_verbose if debug_verbose
+              load_templates_store( key: key, value: value, locale: locale, debug_verbose: debug_verbose )
+            end
+          end
+        end
+      end
+      load_templates_store( key: "#{key_prefix}.loaded", value: "true", debug_verbose: debug_verbose )
+      load_templates_store( key: "#{key_prefix}.last_loaded", value: DateTime.now.to_s, debug_verbose: debug_verbose )
+    end
+
+    def self.load_i18n_templates_process( key:, value:, debug_verbose: )
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "key=#{key}",
+                                             "value=#{value}",
+                                             "" ], bold_puts: debug_verbose if debug_verbose
+      # convert value from yaml to hash of hashes
+      hash = YAML.load( value )
+      # walk hash and store values
+      load_i18n_templates_hash_walk( hash: hash, debug_verbose: debug_verbose )
+    end
+
+    def self.load_i18n_templates_hash_walk( hash:, key_path: '', key: '', locale: '', debug_verbose: )
+
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             ::Deepblue::LoggingHelper.called_from,
+                                             "hash=#{hash}",
+                                             "key_path=#{key_path}",
+                                             "key=#{key}",
+                                             "locale=#{locale}",
+                                             "" ], bold_puts: debug_verbose if debug_verbose
+      prefix = key_path.to_s
+      if locale.blank?
+        locale = key
+      else
+        prefix = "#{prefix}#{key}." if key.present?
+      end
+      ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                             "prefix=#{prefix}",
+                                             "locale=#{locale}",
+                                             "" ], bold_puts: debug_verbose if debug_verbose
+      hash.each do |key,value|
+        if value.is_a?( Hash )
+          load_i18n_templates_hash_walk( hash: value,
+                                         key_path: prefix,
+                                         key: key,
+                                         locale: locale,
+                                         debug_verbose: debug_verbose )
+        else
+          put_key = prefix
+          put_key = "#{prefix}#{key}" if prefix.present?
+          ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                                 ::Deepblue::LoggingHelper.called_from,
+                                                 "key=#{key}",
+                                                 "value=#{value}",
+                                                 "put_key=#{put_key}",
+                                                 "locale=#{locale}",
+                                                 "" ], bold_puts: debug_verbose if debug_verbose
+          load_templates_store( key: put_key, value: value, locale: locale, debug_verbose: debug_verbose )
+        end
+      end
+    end
+
+    def documentation_collection_title
+      @@documentation_collection_title
+    end
+
+    def work_view_content_enable_cache
+      ::DeepBlueDocs::Application.config.static_content_enable_cache
+    end
+
+  end
+
+end

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -48,8 +48,21 @@
     <%# TODO: If we start using ActionCable, we could listen for object updates and
               alert the user that the object has changed by someone else %>
     <%= f.input Hyrax::Actors::OptimisticLockValidator.version_field, as: :hidden if f.object.persisted? %>
-    <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-    <%= link_to t('.cancel'), hyrax.my_works_path, class: 'btn btn-default'%>
+
+    <%# The admin set will tell you if the work is a draft %>
+    <% if f.object.admin_set_id.eql? "admin_set/default" %> <%# creaing work for the first time %>
+      <%= f.submit value: t('helpers.action.work.review'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+      <%= f.submit value: t('helpers.action.work.draft'), class: 'btn2 btn-primary2', onclick: "confirmation_needed = false;", id: "with_files_submit2", name: "save_as_draft"  %>
+      <%= link_to t('.cancel'), hyrax.my_works_path, class: 'btn btn-default'%>
+    <% elsif f.object.admin_set_id.eql? ::Deepblue::DraftAdminSetService.draft_admin_set_id %>  <%# User must be updating draft %>
+      <%= f.submit value: t('helpers.action.work.review'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+      <%= f.submit value: t('helpers.action.work.draft'), class: 'btn2 btn-primary2', onclick: "confirmation_needed = false;", id: "with_files_submit2", name: "save_as_draft"  %>
+      <%= link_to t('.cancel'), hyrax.my_works_path, class: 'btn btn-default' %>
+    <% else %> <%# The updating a work that has been published already %>
+      <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
+      <%= link_to t('.cancel'), hyrax.my_works_path, class: 'btn btn-default'%>
+    <% end %>
+
     <p><%= t('simple_form.actions.data_set.submit_help') %></p>
   </div>
 

--- a/app/views/hyrax/dashboard/_draft_works.html.erb
+++ b/app/views/hyrax/dashboard/_draft_works.html.erb
@@ -1,0 +1,47 @@
+<%  a = ::Deepblue::DraftAdminSetService.draft_admin_set %>
+<% works = a.members %>
+<% if works.size > 0 %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <div style="font-weight: 700;">Your Draft Works</div>
+        </div>
+        <div class="panel-body">
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Author</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% works.each do |work| %>
+                <% if current_ability.can?(:edit, work) %>
+                  <tr>
+                    <td>
+                      <%= link_to work.title.first,
+                          edit_polymorphic_path([main_app, work]),
+                          { title: t('.edit_title', file_set: work) } %></td>
+
+                    <td ><%= work.creator.first %></td> 
+                    <td>
+                      <%= link_to [main_app, work],
+                                  method: :delete,
+                            data: {
+                            confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
+                              <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+                              <span> <%= t("hyrax.dashboard.my.action.delete_work") %> </span>
+                            <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/dashboard/show_admin.html.erb
+++ b/app/views/hyrax/dashboard/show_admin.html.erb
@@ -98,6 +98,7 @@
 </div>
 
 <%= render 'admin_sets' %>
+<%= render 'draft_works' %>
 
 <div class="panel panel-default my_active_embargoes">
   <% if have_assets_under_embargo?( current_ability.current_user.email.to_s ) %>

--- a/app/views/hyrax/my/works/index.html.erb
+++ b/app/views/hyrax/my/works/index.html.erb
@@ -69,6 +69,8 @@
   <% end %>
 <% end %>
 
+<%= render partial: "/hyrax/dashboard/draft_works" %>
+
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default <%= 'tabs' if current_page?(hyrax.dashboard_works_path(locale: nil)) || @managed_works_count > 0 %>">

--- a/config/locales/deepblue.en.yml
+++ b/config/locales/deepblue.en.yml
@@ -8,6 +8,8 @@ en:
         analytics_subscribe: "Subscribe"
         analytics_unsubscribe: "Unsubscribe"
         new: "Add new work"
+        review: "Submit for Review"
+        draft: "Save as Draft"
     select:
       # Default value for :prompt => true in FormOptionsHelper
       prompt: "Please select"

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -169,6 +169,7 @@ en:
           email_template_keys_found:    "Email template keys found:"
         title:              "Manage Email"
       my_active_embargoes:  "Active Embargoes"
+      my_active_drafts:     "Works in Draft Mode"
       my:
         action:
           add_work_to_collection_note: 'Check one or more works to add them to a collection.'

--- a/config/workflows/draft_work_workflow.json
+++ b/config/workflows/draft_work_workflow.json
@@ -1,0 +1,20 @@
+{
+    "workflows": [
+        {
+            "name": "draft work workflow",
+            "label": "Draft Work Workflow",
+            "description": "For Draft Deposits",
+            "allows_access_grant": true,
+            "actions": [
+                {
+                    "name": "deposit",
+                    "from_states": [],
+                    "transition_to": "draft",
+                    "methods": [
+                        "Hyrax::Workflow::GrantEditToDepositor"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/spec/controllers/concerns/deepblue/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/deepblue/works_controller_behavior_spec.rb
@@ -367,14 +367,14 @@ RSpec.describe Hyrax::DataSetsController, :clean_repo do
   # 'update'
   # tested in spec/controllers/hyrax/data_sets_controller_spec.rb
 
-  it 'upate_rest' do  
+  it 'update_rest' do  
     allow(dummy_class).to receive(:curation_concern).and_return test_object
     allow(dummy_class).to receive(:actor_environment).and_return true
     allow(dummy_class).to receive(:actor).and_return test_object
     allow(test_object).to receive(:update).and_return true
     allow(dummy_class).to receive(:after_update_response).and_return true
 
-    dc = dummy_class.upate_rest
+    dc = dummy_class.update_rest "no_id"
     expect(dc).to eq(nil) 
   end
 

--- a/spec/views/hyrax/my/works/index.html.erb_spec.rb
+++ b/spec/views/hyrax/my/works/index.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'hyrax/my/works/index.html.erb', type: :view do
   let(:add_work) { t(:'helpers.action.work.new') }
   let(:subscribe_analytics) { t('simple_form.actions.data_set.analytics_subscribe') }
   let(:unsubcribe_analytics) { t('simple_form.actions.data_set.analytics_unsubscribe') }
+  let( :empty_admin ) { double('adminset') }
 
   before do
     allow(view).to receive(:current_ability).and_return(ability)
@@ -20,6 +21,8 @@ RSpec.describe 'hyrax/my/works/index.html.erb', type: :view do
     allow(view).to receive(:can?).and_return(true)
     allow(Flipflop).to receive(:batch_upload?).and_return(batch_enabled)
     allow(Flipflop).to receive(:disable_desposits_and_edits?).and_return(disable_desposits_and_edits)
+    allow(AdminSet).to receive(:find).and_return empty_admin
+    allow(empty_admin).to receive(:members).and_return []
     stub_template 'shared/_select_work_type_modal.html.erb' => 'modal'
     stub_template 'hyrax/my/works/_tabs.html.erb' => 'tabs'
     stub_template 'hyrax/my/works/_search_header.html.erb' => 'search'


### PR DESCRIPTION
Here is an explanation of some of the technical changes.

So that only the "Submit for Review" button is managed by the js that checks that all required fields are filled in.
app/assets/javascripts/hyrax/save_work/save_work_control.es6
-    this.saveButton = this.element.find(':submit')
+    this.saveButton = this.element.find('#with_files_submit')

In this file
app/controllers/concerns/deepblue/works_controller_behavior.rb 
The methods create and update are defined, and this is where logic was added to take into account if the user during create is:
Creating a new work and requesting a review of the work OR
Creating a new work and just saving it as a draft
AND during update:
Updating a work in the mediated deposit workflow OR
Updating a draft work which is in the Draft works workflow

In this file:
app/views/hyrax/base/_form_progress.html.erb
there is logic to determine what buttons to present users depending on whether the user is creating or updating and if the work is a draft

In this file:
app/views/hyrax/dashboard/show_admin.html.erb
'render draft_works' was added. The _draft_works.html.erb partial is new and it draws the table of drafts if there are any.

This is the new file to render table of draft works:
app/views/hyrax/dashboard/_draft_works.html.erb

Before this PR, there was no update method in the the initialize_work_flow_actor, because now we have 
some special processing required  for the draft work, this actor was subclassed and an update method was added.
This is the file where this happens:
app/actors/hyrax/actors/initialize_workflow_actor.rb

So that the draft works table shows up in the dashboard and dashboard/works pages, this file was updated:
app/views/hyrax/my/works/index.html.erb b/app/views/hyrax/my/works/index.html.erb

The code needs to know the id of the Draft works Admin Set.  This needs to be 
a global variable.  This can be done by making a service with a method that returns the ID based on 
the name of the Draft works Admin Set.  So an Admin Set with the name "Draft works Admin Set" must exists in production, testing and local

This is the way the code access this value:  ::Deepblue::DraftAdminSetService.draft_admin_set_id
A new service was added to handle this:  app/services/deepblue/draft_admin_set_service.rb

For the New Admin:  "Draft works Admin Set", you need a workflow, so a new workflow was created:
config/workflows/draft_work_workflow.json

This workflow needs to be added to the system.  To do that run
bundle exec rake hyrax:workflow:load

And then Create an AdminSet by the name of "Draft works Admin Set", and select this workflow for it.
