### PR TITLE
make save as draft and submit for review button use the same javascript

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/save_work_control.es6
+++ b/app/assets/javascripts/hyrax/save_work/save_work_control.es6
@@ -51,7 +51,7 @@ export default class SaveWorkControl {
   preventSubmitIfAlreadyInProgress() {
     this.form.on('submit', (evt) => {
       if (this.isValid())
-        this.saveButton.prop("disabled", true);
+         this.saveButton.prop("disabled", false); 
     })
   }
 
@@ -83,7 +83,7 @@ export default class SaveWorkControl {
     }
     this.requiredFields = new RequiredFields(this.form, () => this.formStateChanged())
     this.uploads = new UploadedFiles(this.form, () => this.formStateChanged())
-    this.saveButton = this.element.find('#with_files_submit')
+    this.saveButton = this.element.find(':submit')
     this.depositAgreement = new DepositAgreement(this.form, () => this.formStateChanged())
     this.requiredMetadata = new ChecklistItem(this.element.find('#required-metadata'))
     this.requiredFiles = new ChecklistItem(this.element.find('#required-files'))

--- a/app/views/hyrax/base/_form_progress.html.erb
+++ b/app/views/hyrax/base/_form_progress.html.erb
@@ -52,11 +52,11 @@
     <%# The admin set will tell you if the work is a draft %>
     <% if f.object.admin_set_id.eql? "admin_set/default" %> <%# creaing work for the first time %>
       <%= f.submit value: t('helpers.action.work.review'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-      <%= f.submit value: t('helpers.action.work.draft'), class: 'btn2 btn-primary2', onclick: "confirmation_needed = false;", id: "with_files_submit2", name: "save_as_draft"  %>
+      <%= f.submit value: t('helpers.action.work.draft'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "save_as_draft", name: "save_as_draft"  %>
       <%= link_to t('.cancel'), hyrax.my_works_path, class: 'btn btn-default'%>
     <% elsif f.object.admin_set_id.eql? ::Deepblue::DraftAdminSetService.draft_admin_set_id %>  <%# User must be updating draft %>
       <%= f.submit value: t('helpers.action.work.review'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>
-      <%= f.submit value: t('helpers.action.work.draft'), class: 'btn2 btn-primary2', onclick: "confirmation_needed = false;", id: "with_files_submit2", name: "save_as_draft"  %>
+      <%= f.submit value: t('helpers.action.work.draft'), class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "save_as_draft", name: "save_as_draft"  %>
       <%= link_to t('.cancel'), hyrax.my_works_path, class: 'btn btn-default' %>
     <% else %> <%# The updating a work that has been published already %>
       <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "with_files_submit", name: "save_with_files" %>


### PR DESCRIPTION
With this PR the "Save as Draft" and "Submit for Review" are enabled and disabled using the same criteria - basically that the required fields are filled in.

I want to point out  the difference between these two lines:
This grabs a specific id:
    this.saveButton = this.element.find('#with_files_submit')
This grabs ALL submit buttons.
    this.saveButton = this.element.find(':submit')

One thing that was challenging about this PR was that in the method preventSubmitIfAlreadyInProgress it was doing this:
        this.saveButton.prop("disabled", true);

which did not send the submit buttons value on to the controller and so this line was returning nil always:
         draft = params[:save_as_draft]

I changed the code in preventSubmitIfAlreadyInProgress to:
         this.saveButton.prop("disabled", false); 

And the params returned the values in the submit button.  I did not see any ill effects from making this change.


