### PR TITLE
deactivate work in draft mode.

### DIFF
--- a/config/workflows/draft_work_workflow.json
+++ b/config/workflows/draft_work_workflow.json
@@ -11,7 +11,8 @@
                     "from_states": [],
                     "transition_to": "draft",
                     "methods": [
-                        "Hyrax::Workflow::GrantEditToDepositor"
+                        "Hyrax::Workflow::GrantEditToDepositor",
+                        "Hyrax::Workflow::DeactivateObject"
                     ]
                 }
             ]


### PR DESCRIPTION
When you deactivate a work that has been saved as draft, it will not show up when you hit "Go" from the home page.  Only active works show up when searching.  

As reference, this is what the deactivate code does:

app/services/hyrax/workflow/deactivate_object.rb  (in the hyrax gem code):

module DeactivateObject
  def self.call(target:, **)
    target.state = Vocab::FedoraResourceStatus.inactive
  end
end