### PR TITLE
corrections to csv functionality

### DIFF
--- a/app/controllers/hyrax/stats_controller.rb
+++ b/app/controllers/hyrax/stats_controller.rb
@@ -16,9 +16,13 @@ module Hyrax
     end
 
     # To download csv files.
-    def cvs_download
+    def csv_download
       @stats = Hyrax::WorkUsage.new(params[:id])
-      send_data @stats.to_csv
+      filename = params[:id] + "_stats.csv"
+      #This is an example that worked
+      #send_data @stats.to_csv, :type => 'text/csv; charset=utf-8; header=present', :disposition => 'attachment; filename=payments.csv'
+      target = "attachment`; filename=#{filename}"
+      send_data @stats.to_csv, :type => 'text/csv; charset=utf-8; header=present', :disposition => target
     end
 
     def file

--- a/app/presenters/hyrax/work_usage.rb
+++ b/app/presenters/hyrax/work_usage.rb
@@ -17,17 +17,41 @@ module Hyrax
     def to_csv
       data = self.to_flot[0][:data] 
 
-      attributes = %w{date count}
-      CSV.generate(headers: true) do |csv|
-        csv << attributes
+      #This was used to test logic
+      #data=[["a", 1], ["a", 2], ["b", 3], ["x", 7], ["c", 4], ["c", 5], ["y", 100]]
 
-        data.uniq.each do |sub_array|
-         time = Time.at sub_array[0].to_i/1000
-         count = sub_array[1]
-
-         csv << [time, count]
+      cnt = 0
+      final_data = []
+      data.uniq.each do |sub_array|
+        time = sub_array[0]
+        count = sub_array[1]
+        if cnt < 1 
+           final_data << [time, count]
+        else
+          sample = final_data.last
+          if ( cnt < data.size ) && ( sample[0].eql? time )
+            final_data.last[1] = final_data.last[1] + count
+          else
+            final_data << [time, count]
+          end
         end
-      end
+        cnt += 1
+       end
+
+       title = ["title => " + self.work.title.first]
+       attributes = %w{date count}
+
+       CSV.generate(headers: true) do |csv|
+         csv << title
+         csv << attributes
+
+         final_data.uniq.each do |sub_array|
+          time = Time.at sub_array[0].to_i/1000
+          count = sub_array[1]
+
+          csv << [time, count]
+         end
+       end
     end
 
     # Package data for visualization using JQuery Flot

--- a/app/views/hyrax/stats/work.html.erb
+++ b/app/views/hyrax/stats/work.html.erb
@@ -57,9 +57,9 @@
 <% end %>
 
 <% if current_ability.admin? %>
-  <%= form_tag(main_app.cvs_download_hyrax_data_set_path(params[:id]), method: 'post') do %>
+  <%= form_tag(main_app.csv_download_hyrax_data_set_path(params[:id]), method: 'post') do %>
     <%= submit_tag(t('simple_form.actions.data_set.csv_download'),
-                   class: 'btn btn-subtle') %>
+                   class: 'btn btn-primary') %>
   <% end %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -193,8 +193,8 @@ Rails.application.routes.draw do
         post   'tombstone'
         get    'zip_download'
         post   'zip_download'
-        get    'cvs_download', controller: 'stats', action: :cvs_download
-        post   'cvs_download', controller: 'stats', action: :cvs_download
+        get    'csv_download', controller: 'stats', action: :csv_download
+        post   'csv_download', controller: 'stats', action: :csv_download
       end
     end
   end


### PR DESCRIPTION
In this PR I took care of my typo of using cvs when I should have been using csv.

I make the color of the text in the button white using the class `btn-primary`

When the csv file is output, it will contain the title of the work in the first line.  This is the code that does that:
```title = ["title => " + self.work.title.first]```

The output file name will follow this format:  workid_stats.csv.  You can see this being done in this code:

      filename = params[:id] + "_stats.csv"
      #This is an example that worked
      #send_data @stats.to_csv, :type => 'text/csv; charset=utf-8; header=present', :disposition => 'attachment; 
      filename=payments.csv'
      target = "attachment`; filename=#{filename}"
      send_data @stats.to_csv, :type => 'text/csv; charset=utf-8; header=present', :disposition => target

Also I put in logic to "merge/condense" the counts per day.  This can be found app/presenters/hyrax/work_usage.rb.  Notice I have commented out some sample data I used to test on my local machine.  I did the same in the view code on a previous PR.
