### PR TITLE
filter out works in draft admin set from the list of works and my works

### DIFF
--- a/app/search_builders/hyrax/filter_suppressed.rb
+++ b/app/search_builders/hyrax/filter_suppressed.rb
@@ -32,6 +32,10 @@ module Hyrax
 
     end
 
+    def remove_draft_works(solr_parameters)
+      solr_parameters[:fq] << "{!df=admin_set_sim}NOT \"Draft works Admin Set\""
+    end
+
 
     private
 

--- a/app/search_builders/hyrax/my/works_search_builder.rb
+++ b/app/search_builders/hyrax/my/works_search_builder.rb
@@ -12,6 +12,7 @@ module Hyrax
     # self.default_processor_chain -= [:add_access_controls_to_solr_params]
     # We remove the active works filter, so a depositor can see submitted works in any state.
     self.default_processor_chain -= [:only_active_works, :add_access_controls_to_solr_params]
+    self.default_processor_chain += [:remove_draft_works]
 
     def only_works?
       true

--- a/app/search_builders/hyrax/works_search_builder.rb
+++ b/app/search_builders/hyrax/works_search_builder.rb
@@ -1,0 +1,14 @@
+module Hyrax
+  # Returns all works, either active or suppressed.
+  # This should only be used by an admin user
+  class WorksSearchBuilder < Hyrax::SearchBuilder
+    include Hyrax::FilterByType
+    self.default_processor_chain -= [:only_active_works]
+    self.default_processor_chain += [:remove_draft_works]
+
+
+    def only_works?
+      true
+    end
+  end
+end


### PR DESCRIPTION
In app/controllers/hyrax/my/works_controller.rb, you point to the search builder being used for the "My" tab:

      def search_builder_class
        Hyrax::My::WorksSearchBuilder
      end

in app/search_builders/hyrax/my/works_search_builder.rb, you point to the filter method you need

    self.default_processor_chain += [:remove_draft_works]

AND

In app/controllers/concerns/hyrax/works_controller_behavior.rb   (look at hyrax gem code, 
this file is monkey patched ), you point to the search builder being used for the "All" tab:

      self.search_builder_class = WorkSearchBuilder

in app/search_builders/hyrax/works_search_builder.rb, you point to the filter method you need.

    self.default_processor_chain += [:remove_draft_works]


In app/search_builders/hyrax/filter_suppressed.rb, you add the remove_draft_works method

    def remove_draft_works(solr_parameters)
      solr_parameters[:fq] << "{!df=admin_set_sim}NOT \"Draft works Admin Set\""
    end


A few notes about this code `solr_parameters[:fq] << "{!df=admin_set_sim}NOT \"Draft works Admin Set\""`

If you set a breakpoint at remove_draft_works, you can examine the solr_parameters, and experiment with 
changing the fq (facet query).  I got some help with the way to exclude an admin_set from the results from Bill.

Here are some notes from my conversation with Bill:

   The syntax {!<something> <arg>=XXX}Search Text is to do a query with a specific query parser -- you may have seen {!edismax qf=XXX}Query text at some point. There's a shorthand for the "default lucene query parser" to use just an exclamation point, so {! <arg>=XXX} is the same as {!lucene <arg>=XXX}.

   The arguments in the braces correspond to legal arguments for that type of query parser. So an edismax query would have qf, pf, etc. The lucene query parser uses "default field to search" as df
   https://solr.apache.org/guide/8_0/query-syntax-and-parsing.html gives an overview (over several pages) of the various query parsers available by default in a solr installation.
   I'm 99% sure that solr assumes lucene (or solr basic, which is very similar) if you don't specify, so you probably could have just gone with fq=admin_set_sim:(NOT "Draft words Admin Set")

Also, I found out working on this PR that if you want to exclude a facet value ( say the admin set facet  for draft admin sets) from the list of admin sets, you can do this:

   solr_parameters['f.admin_set_sim.facet.excludeTerms'] = "Draft works Admin Set"

In this particular example the works belonging to the draft admin set were still showing up. This setting just removes it from the facet selection.

