### PR TITLE
change to sword default collection setting

### DIFF
--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -6,7 +6,7 @@ WillowSword.setup do |config|
   config.title = 'Deep Blue Data Sword V2 server'
   # If you do not want to use collections in Sword, it will use this as a default collection
   # This is the default collection in production
-  config.default_collection = {id: 'bk128999s', title: ['University of Michigan Museum of Zoology']}
+  config.default_collection = {id: '5999n365p', title: ['SWORD Default Collection']}
   # The name of the model for retreiving collections (based on Hyrax integration)
   config.collection_models = ['Collection']
   # The work models supported by Sword (based on Hyrax integration)


### PR DESCRIPTION
Here is some additional info on sword.

(1)  The config is set here:
config/initializers/willow_sword.rb

Note that the default collection for sword, is the one with this name: SWORD Default Collection


(2)  The default collection is: 

https://deepblue.lib.umich.edu/data/collections/5999n365p

(If you want to experiment in testing this will have to 
 be changed manually to use a different default collection)

(3) The sword request can either use "default" or actual collection ids. Notice that 
for the The_key, you will have to use the key I provided.  Also, always use https.
For example:

curl --request GET \
    --url 'https://testing.deepblue.lib.umich.edu/data/sword/collections/3j3332324' \
    --header 'Content-Type: application/xml' \
    --header 'Api-key:The_key'

If all is configured correctly you can use default instead of the actual collie

curl --request GET \
    --url 'https://testing.deepblue.lib.umich.edu/data/sword/collections/default' \
    --header 'Content-Type: application/xml' \
    --header 'Api-key:The_key'


(4) For a POST request like this one, you will have to create a dc file that contains all the required fields:

curl --request POST   --url https://testing.deepblue.lib.umich.edu/data/sword/collections/3j3332324/works    \
  --header 'Content-Disposition: attachment; filename=metadata.xml'  \
  --header 'Content-Type: application/xml'   \
  --header 'In-Progress: false'   \
  --header 'Api-key:The_key'   \
  --header 'Packaging: application/atom+xml;type=entry'   \
  --data-binary @dc.xml

Here is an example dc.xml file:

First, this is an important file because it has the mapping from data to willow metadata:

https://github.com/mlibrary/deepblue/blob/master/app/services/willow_sword/crosswalk_from_dc_data.rb


And I believe the required fields are(https://github.com/mlibrary/deepblue/blob/master/app/forms/hyrax/data_set_form.rb#L58):

    self.required_fields =
      %i[
        title
        creator
        authoremail
        methodology
        description
        rights_license
        subject_discipline
      ]


<?xml version="1.0" encoding="UTF-8"?>
<metadata
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns:dc="http://purl.org/dc/elements/1.1/">
  <dc:title>Test record</dc:title>
  <dc:creator>Anusha</dc:creator>
  <dc:subject>Sword</dc:subject>
  <dc:subject>Crosswalk</dc:subject>
  <dc:description>This is a test dc record to test the dc crosswalk</dc:description>
  <dc:publisher>Digital Nest</dc:publisher>
  <dc:contributor>The dublin core generator</dc:contributor>
  <dc:source>http://sword.digitalnest.com</dc:source>
  <dc:language>English</dc:language>
  <dc:relation>http://example.com</dc:relation>
  <dc:methodology>Sword</dc:methodology>
  <dc:authoremail>blancoj@umich.edu</authoremail>
  <dc:rights_license>CC-0</dc:rights_license>
</metadata>



There is more information on this at this site:

https://github.com/CottageLabs/willow_sword/wiki/Usage#add-new-work-metadata-only-binary