### PR TITLE
send notification when in draft and when transitioning to mediated workflow

### DIFF
--- a/app/actors/hyrax/actors/initialize_workflow_actor.rb
+++ b/app/actors/hyrax/actors/initialize_workflow_actor.rb
@@ -57,6 +57,19 @@ module Hyrax
           entity.update!( workflow: wf, workflow_state_id: action.id, workflow_state: wf_state )
 
           next_actor.create(env) # TODO: should this be next_actor.update(env) ??
+
+          #Send a notification letting it known that the work has transition from draft to mediated workflow
+          notifier = Hyrax::Workflow::NotificationService.new(entity: entity, action: action, comment: true, user: env.user)
+
+          notification = Sipity::Notification.new
+          notification.id = 1
+          notification.name ="Hyrax::Workflow::PendingReviewNotification"
+          notification.notification_type ="email"
+          now = Time.now.strftime("%Y-%m-%d")
+          notification.created_at = now
+          notification.updated_at = now
+
+          notifier.send_notification(notification)
         else
           super
         end

--- a/app/services/hyrax/workflow/draft_creation_notification.rb
+++ b/app/services/hyrax/workflow/draft_creation_notification.rb
@@ -1,0 +1,19 @@
+module Hyrax
+  module Workflow
+    class DraftCreationNotification < AbstractNotification
+      private
+
+        def subject
+          'Draft work created'
+        end
+
+        def message
+          "#{title} (#{link_to work_id, document_path}) was created by #{user.user_key} as a draft work"
+        end
+
+        def users_to_notify
+          super << user
+        end
+    end
+  end
+end

--- a/config/workflows/draft_work_workflow.json
+++ b/config/workflows/draft_work_workflow.json
@@ -10,6 +10,13 @@
                     "name": "deposit",
                     "from_states": [],
                     "transition_to": "draft",
+                    "notifications": [
+                        {
+                            "notification_type": "email",
+                            "name": "Hyrax::Workflow::DraftCreationNotification",
+                            "to": []
+                        }
+                    ],
                     "methods": [
                         "Hyrax::Workflow::GrantEditToDepositor",
                         "Hyrax::Workflow::DeactivateObject"


### PR DESCRIPTION
This file has changed: config/workflows/draft_work_workflow.json

So this has to be run:
bundle exec rake hyrax:workflow:load

I'm not sure if the "Draft works Admin Set" need to be edited and saved to have the changes in the workflow applied to it.  I did it on my local machine.

