### PR TITLE
changes to fine tune schema.org

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -1,0 +1,5 @@
+<li id="document_<%= document.to_param %>" class="document <%= render_document_class document %>">
+  <div class="row search-result-wrapper">
+    <%= render_document_partials document, blacklight_config.view_config(document_index_view_type).partials, document_counter: document_counter %>
+  </div>
+</li>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -38,7 +38,7 @@
   <span class="hide"><%= Rails.application.routes.url_helpers.hyrax_data_set_url( id: presenter.id ) %></span>
 </span>
 
-<%= presenter.attribute_to_html(:creator, render_as: :faceted, label: t('show.labels.creator') ) %>
+<%= raw (presenter.attribute_to_html(:creator, render_as: :faceted, label: t('show.labels.creator') )).gsub!('itemscope itemtype="http://schema.org/Person"', '') %>
 
 
 <% presenter.depositor.gsub!('@', 'at_sign_at') %>
@@ -82,7 +82,7 @@
 
 <%= presenter.attribute_to_html(:source) %>
 
-<span itemprop="identifier" itemscope itemtype="http://schema.org/Identifier">
+<span itemprop="identifier">
   <%= presenter.attribute_to_html(:doi, label: t('show.labels.doi'), work_type: "DataSet", render_as: :doi ) %>
 </span>
 

--- a/app/views/hyrax/base/_metadata.html.erb
+++ b/app/views/hyrax/base/_metadata.html.erb
@@ -6,7 +6,7 @@
 <%   end %>
 <% end %>
 
-<dl class="work-show  <%= dom_class(presenter) %>" itemscope itemtype="<%= itemtype %>"> 
+<dl class="work-show  <%= dom_class(presenter) %>"> 
     <%= render 'attribute_rows', presenter: presenter %>
     <%= presenter.attribute_to_html(:embargo_release_date, render_as: :date, html_dl: true) %>
     <%= presenter.attribute_to_html(:lease_expiration_date, render_as: :date, html_dl: true) %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -16,7 +16,7 @@
     <%= render 'work_type', presenter: @presenter %>
   </div>
   <div class="col-xs-12">&nbsp;</div>
-  <div itemscope itemtype="<%= @presenter.itemscope_itemtype %>" class="col-xs-12">
+  <div>
     <div class="panel panel-default work-details-container">
       <%= render 'work_description_and_title', presenter: @presenter %>
       <%= render 'show_work_body' %>

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -46,9 +46,7 @@ signed in %>
        "@type": "Organization",     
        "legalName": "University of Michigan - Deep Blue Data",     
        "name": "Deep Blue Data",     
-       "url": "https://deepblue.lib.umich.edu/data"},
-    "provider":
-      {"@id": "https://deepblue.lib.umich.edu/data"}
+       "url": "https://deepblue.lib.umich.edu/data"}
   }
   </script>
 <% end %>

--- a/app/views/records/show_fields/_contributor.html.erb
+++ b/app/views/records/show_fields/_contributor.html.erb
@@ -1,0 +1,6 @@
+<% record.contributor.each do |contributor| %>
+  <span itemprop="contributor">
+    <span itemprop="name"><%= link_to_field('contributor', contributor) %></span>
+  </span>
+  <br />
+<% end %>

--- a/app/views/records/show_fields/_creator.html.erb
+++ b/app/views/records/show_fields/_creator.html.erb
@@ -1,0 +1,6 @@
+<% record.creator.each do |creator| %>
+<span itemprop="creator">
+  <span itemprop="name"><%= link_to_facet(creator, Solrizer.solr_name("creator", :facetable)) %></span>
+</span>
+<br />
+<% end %>


### PR DESCRIPTION
This PR has some fine tuning for the schema.org used by Google to index us.

Here is what to know:
(1)  We are not displaying any schema info in browse or search results.  The change to this file takes care of that:
app/views/catalog/_document.html.erb 

If you look at what is in the hyrax gem for this file, you will see it included the schema info.  

The reason we decided to do this is because the Google index checker tool was complaining that there was no metadata available for the item just marked as a Dataset ( the code was not marking the metadata with the appropriate schema indicators).  And secondly, and most importantly, we really did not want to index the search and browse page, just the item page.

(2)  The other changes in this PR are to remove inline schema.org from showing up in the item show page.  Hyrax by default does that, but we found it more useful to create a json object for the item page, and if you have both (json and the inline schema indicators) displayed on the page, Google saw it as an error.

Again, some testing for these changes were done using this tool:
https://validator.schema.org/#url=https%3A%2F%2Fdeepblue.lib.umich.edu%2Fdata%2Fconcern%2Fdata_sets%2Frf55z7781%3Flocale%3Den
