### PR TITLE
generate sitemap code

### DIFF
--- a/app/jobs/sitemap_generator_job.rb
+++ b/app/jobs/sitemap_generator_job.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../services/deepblue/sitemap_generator_service'
+
+class SitemapGeneratorJob < ::Deepblue::DeepblueJob
+
+SCHEDULER_ENTRY = <<-END_OF_SCHEDULER_ENTRY
+
+sitemap_generator_job:
+  # Run once a week at midnight
+  #      M H D
+  # cron: '*/5 * * * *'
+  cron: '0 5 * * 0'
+  class: SitemapGeneratorJob
+  queue: default
+  description: Sitemap generator job.
+  args:
+    hostnames:
+      - 'deepblue.lib.umich.edu'
+      - 'staging.deepblue.lib.umich.edu'
+      - 'testing.deepblue.lib.umich.edu'
+
+END_OF_SCHEDULER_ENTRY
+
+  queue_as :default
+
+  def perform( *args )
+    initialize_options_from( *args )
+    log( event: "sitemap generator job", hostname_allowed: hostname_allowed? )
+    is_quiet?
+    return job_finished unless hostname_allowed?
+
+    Deepblue::SitemapGeneratorService.generate_sitemap
+
+    job_finished
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    job_status_register( exception: e, args: args )
+    email_failure( task_name: self.class.name, exception: e, event: self.class.name )
+    raise
+  end
+
+end

--- a/app/services/deepblue/sitemap_generator_service.rb
+++ b/app/services/deepblue/sitemap_generator_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Deepblue
+
+  # nabbed from heliotrope
+  module SitemapGeneratorService
+
+    def self.generate_sitemap
+
+      src = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+      src += "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
+      DataSet.all.each do |work|
+        next unless work.published?  
+        next unless work.embargo_release_date.nil?
+        if !work.embargo_release_date.nil?
+          next if work.embargo_release_date <= Date.today
+        end
+
+        url = work.data_set_url
+        url = work.data_set_url.gsub("http:", "https:") if work.data_set_url.include? "http:"
+        src += "<url>\n"
+        src += "<loc>" + url + "</loc>\n"
+        src += "<lastmod>" + work.date_modified.to_datetime.to_s + "</lastmod>\n"
+        src += "<changefreq>weekly</changefreq>\n"
+        src += "<priority>0.5</priority>\n"
+        src += "</url>\n"
+      end
+      src += "</urlset>\n"
+
+      # I the file should be accessible here
+      # http://localhost:3000/data/sitemap.xml
+      # in which case it needs to go in the public dir
+      sitemap_file = Rails.root.join('public', 'sitemap.xml').to_s
+      File.open(sitemap_file, 'w') { |file| file.write(src) }
+
+    end
+    
+  end
+end

--- a/lib/tasks/create_sitemap.rake
+++ b/lib/tasks/create_sitemap.rake
@@ -1,0 +1,9 @@
+namespace :deepblue do
+
+  # bundle exec rake deepblue:create_sitemap
+  desc 'Create sitemap'
+  task create_sitemap: :environment do
+    Deepblue::SitemapGeneratorService.generate_sitemap
+  end
+  
+end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,5 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+Sitemap: https://deepblue.lib.umich.edu/data/sitemap.xml


### PR DESCRIPTION
https://tools.lib.umich.edu/jira/browse/BLUEDOC-1260

From my conversation on how fulcrum does their sitemap with Seth:
They use a gem.  Seth gave me these links to their code:
(1) the gem they use:  https://github.com/kjvarga/sitemap_generator
(2) how they set it up on the robots file:  https://www.fulcrum.org/robots.txt
(3) Their specific code change for the gem: https://github.com/mlibrary/heliotrope/blob/master/config/sitemap.rb
(4) link to their master sitemap file: https://www.fulcrum.org/sitemap.xml
(5) An example of one of their sitemap files.
https://www.fulcrum.org/sitemap2.xml

```<url>
<loc>https://www.fulcrum.org/concern/file_sets/5h73px66g</loc>
<lastmod>2019-10-02T01:07:08Z</lastmod>
<changefreq>monthly</changefreq>
<priority>0.5</priority>
</url>

(6) They build their sitemap every time they do a deploy ( part of the process ).  This happens every 3 weeks.

I used this info and the stuff in the dspace documentation to build this code.  We agreed that we should run the sitemap build every week and put it in the scheduler. I built a rake task just to have it.


Here is some more info on sitemap building:
https://www.sitemaps.org/protocol.html