### PR TITLE
send notification and email to depositor when work is deleted.

### DIFF
--- a/app/models/concerns/deepblue/email_behavior.rb
+++ b/app/models/concerns/deepblue/email_behavior.rb
@@ -36,6 +36,10 @@ module Deepblue
       return attributes_standard_for_email, USE_BLANK_KEY_VALUES
     end
 
+    def attributes_for_email_event_destroy_user
+      return attributes_standard_for_email, USE_BLANK_KEY_VALUES
+    end
+
     def attributes_for_email_event_globus_rds
       return attributes_brief_for_email, IGNORE_BLANK_KEY_VALUES
     end
@@ -171,6 +175,42 @@ module Deepblue
                                        ignore_blank_key_values: ignore_blank_key_values,
                                        return_email_body: true )
       ::Deepblue::JiraHelper.jira_add_comment( curation_concern: self, event: EVENT_DESTROY, comment: body )
+    end
+
+    def email_event_destroy_user( current_user:, event_note: '', was_draft: false )
+      to, _to_note, from = email_address_user( current_user )
+      cc_title = EmailHelper.cc_title curation_concern: self
+      cc_type = EmailHelper.curation_concern_type( curation_concern: self )
+      cc_url = EmailHelper.curation_concern_url( curation_concern: self )
+      cc_depositor = EmailHelper.cc_depositor( curation_concern: self )
+      Deepblue::LoggingHelper.bold_debug [ Deepblue::LoggingHelper.here,
+                                           Deepblue::LoggingHelper.called_from,
+                                           "to, to_note, from=#{to}, #{_to_note}, #{from}",
+                                           "cc_type=#{cc_type}",
+                                           "cc_title=#{cc_title}",
+                                           "cc_url=#{cc_url}",
+                                           "cc_depositor=#{cc_depositor}",
+                                           "" ] if email_behavior_debug_verbose
+      body = EmailHelper.t( email_template_key( cc_type: cc_type, event: 'destroyed', was_draft: was_draft ),
+                            title: EmailHelper.escape_html( cc_title ),
+                            url: cc_url,
+                            depositor: cc_depositor,
+                            contact_us_at: ::Deepblue::EmailHelper.contact_us_at )
+      email_notification( to: to,
+                          from: from,
+                          content_type: "text/html",
+                          subject: ::Deepblue::EmailHelper.t( "hyrax.email.subject.#{cc_type}_deleted" ),
+                          body: body,
+                          current_user: current_user,
+                          event: EVENT_DESTROY,
+                          event_note: event_note,
+                          id: for_email_id )
+
+      #Send the dopositor a notification that the work was deleted.
+      message = I18n.t('hyrax.email.message.deleted_message') + cc_url
+      message = I18n.t('hyrax.email.message.deleted_draft_message') + cc_url if was_draft
+
+      Hyrax::MessengerService.deliver(current_user, current_user, message, ::Deepblue::EmailHelper.t( "hyrax.email.subject.#{cc_type}_deleted" ))
     end
 
     def email_event_globus_rds( current_user:, event_note: )

--- a/app/models/concerns/deepblue/workflow_event_behavior.rb
+++ b/app/models/concerns/deepblue/workflow_event_behavior.rb
@@ -56,6 +56,10 @@ module Deepblue
                                              "" ] if workflow_event_behavior_debug_verbose
       provenance_destroy( current_user: current_user, event_note: event_note )
       email_event_destroy_rds( current_user: current_user, event_note: event_note )
+
+      # Send an email to the user ( depositor )
+      is_draft = ::Deepblue::DraftAdminSetService.has_draft_admin_set?( self )
+      email_event_destroy_user( current_user: current_user, event_note: event_note, was_draft: is_draft )
     end
 
     def workflow_publish( current_user:, event_note: "", message: "" )

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -572,6 +572,9 @@ en:
         work_doi_minted:    "DBD: DOI Minted"
         work_published:     "DBD: Work Published"
         work_unpublished:   "DBD: Work Unpublished"
+      message:
+        deleted_message:        "This work has been deleted : "
+        deleted_draft_message:  "This DRAFT work has been deleted : "
     embargo:
       copy_visibility_flash_message: >
         Updating file permissions. This may take a few minutes. You may want to refresh your browser or return


### PR DESCRIPTION
This addresses jira ticket:  https://tools.lib.umich.edu/jira/browse/BLUEDOC-568

Before this ticket, when a work was deleted, RDS received an email.  This tickets adds the following functionality:

Depository will also get an email, plus a  notification.

We talked about sending RDS a notification also, but decided against it because they don't use that very much, in addition the notification process in Hyrax is a bit complicated.  We could do something like this in email_behavior.rb in the method email_event_destroy_rds:

message = "This work has been deleted = " + EmailHelper.curation_concern_url( curation_concern: self )
admin_users = RoleMapper.map["admin"]
admin_users.each do |admin_email|
   user = User.find_by_user_key admin_email
   Hyrax::MessengerService.deliver(current_user, admin_user, message, ::Deepblue::EmailHelper.t( "hyrax.email.subject.#{cc_type}_deleted" )) unless amin_user.nil?
end

This code would send a notification to everyone in the admin section of the role_map.yml file, which would be all admins, and this is probably not what we want.  The thing with notifications is that it is controlled in the mediated_workflow.json file and it interacts with the Sipity tables, which gets complicated and since after talking to Susan and Rachel on RDS it seemed this was not so necessary, we decided not to bother sending the notifications to RDS.