### PR TITLE
so that title sort can be done on works and collections.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -485,8 +485,8 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{modified_field} asc", label: "last modified \u25B2"
 
     # Need to reindex the collection to be able to use these.
-    # config.add_sort_field "titl_ssi desc", label: "date modified \u25BC"
-    # config.add_sort_field "title_ssi asc", label: "date modified \u25B2"
+    config.add_sort_field "title_ssi desc", label: "title \u25BC"
+    config.add_sort_field "title_ssi asc", label: "title \u25B2"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/indexers/data_set_indexer.rb
+++ b/app/indexers/data_set_indexer.rb
@@ -34,12 +34,11 @@ class DataSetIndexer < Hyrax::WorkIndexer
       # value = Array( object.referenced_by ).join( " " )
       # solr_doc[Solrizer.solr_name('referenced_by', :stored_searchable)] = value
 
-      # So that we can sort by title.
+      # So that title sort can be done ...
       value = Array( object.title ).join( " " )
-      solr_doc[Solrizer.solr_name('title', :stored_searchable,)] = value
+      solr_doc[Solrizer.solr_name('title', :stored_searchable)] = value
       solr_doc[Solrizer.solr_name('title', :stored_sortable)] = value
 
-      solr_doc[Solrizer.solr_name('title_ordered', :stored_searchable)] = object.title_ordered
       solr_doc[Solrizer.solr_name('tombstone', :symbol)] = object.tombstone
       # solr_doc[Solrizer.solr_name('total_file_size', Hyrax::FileSetIndexer::STORED_LONG)] = object.total_file_size
       solr_doc[Solrizer.solr_name('total_file_size', Hyrax::FileSetIndexer::STORED_LONG)] = object.size_of_work

--- a/app/indexers/hyrax/admin_set_indexer.rb
+++ b/app/indexers/hyrax/admin_set_indexer.rb
@@ -1,0 +1,20 @@
+module Hyrax
+  class AdminSetIndexer < ActiveFedora::IndexingService
+    include Hyrax::IndexesThumbnails
+
+    self.thumbnail_path_service = Hyrax::CollectionThumbnailPathService
+
+    def generate_solr_document
+      super.tap do |solr_doc|
+
+        # Makes Admin Sets show under the "Admin Sets" tab
+        Solrizer.set_field(solr_doc, 'generic_type', 'Admin Set', :facetable)
+
+        # So that title sort can be done ...
+        value = Array( object.title ).join( " " )
+        solr_doc[Solrizer.solr_name('title', :stored_searchable)] = value
+        solr_doc[Solrizer.solr_name('title', :stored_sortable)] = value
+      end
+    end
+  end
+end

--- a/app/indexers/hyrax/collection_indexer.rb
+++ b/app/indexers/hyrax/collection_indexer.rb
@@ -1,0 +1,29 @@
+module Hyrax
+  class CollectionIndexer < Hydra::PCDM::CollectionIndexer
+    include Hyrax::IndexesThumbnails
+
+    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
+
+    self.thumbnail_path_service = Hyrax::CollectionThumbnailPathService
+
+    # @yield [Hash] calls the yielded block with the solr document
+    # @return [Hash] the solr document WITH all changes
+    def generate_solr_document
+      super.tap do |solr_doc|
+        # Makes Collections show under the "Collections" tab
+        solr_doc['generic_type_sim'] = ["Collection"]
+        solr_doc['visibility_ssi'] = object.visibility
+
+        # So that title sort can be done ...
+        value = Array( object.title ).join( " " )
+        solr_doc[Solrizer.solr_name('title', :stored_searchable)] = value
+        solr_doc[Solrizer.solr_name('title', :stored_sortable)] = value
+
+        object.in_collections.each do |col|
+          (solr_doc['member_of_collection_ids_ssim'] ||= []) << col.id
+          (solr_doc['member_of_collections_ssim'] ||= []) << col.to_s
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When we go to testing and production, all collections, admin sets, and works will have to be re-index.

This is the JIRA ticket:
https://tools.lib.umich.edu/jira/browse/BLUEDOC-609