### PR TITLE
check logo id is string not just public.

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -103,6 +103,24 @@ module Hyrax
         add_new_banner(uploaded_file_ids) if uploaded_file_ids
       end
 
+      def process_logo_records(uploaded_file_ids)
+        public_files = []
+        uploaded_file_ids.each_with_index do |ufi, i|
+          # If user has chosen a new logo, the ufi will be an integer
+          # If the logo was previously chosen, the ufil will be a path
+          # ufi.match(/\D/) will return a nil, fi ufi is an integer
+          # if it is a path, you want to update the, else create a new rec
+          if ! ufi.match(/\D/).nil?
+            update_logo_info(ufi, params["alttext"][i], verify_linkurl(params["linkurl"][i]))
+            public_files << ufi
+          else # brand new one, insert in the database
+            logo_info = create_logo_info(ufi, params["alttext"][i], verify_linkurl(params["linkurl"][i]))
+            public_files << logo_info.local_path
+          end
+        end
+        public_files
+      end
+
       def update_existing_banner
         # ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
         #                                        ::Deepblue::LoggingHelper.called_from,


### PR DESCRIPTION
This fixes issue:

https://tools.lib.umich.edu/jira/browse/BLUEDOC-1024

When you upload a logo for the 1st time for a collection, the file ID is numeric.  When you go back to the branding page and you try to save it again, the file ID is no longer numeric, but a path.  The code was checking that the path contained "public," but for some reason, it did not contain "public," so I changed the code to check that it contained a string.

General rule:
New logo file ids will contain a numeric value.
Existing logo file ids will contain a path.

Not quite sure why "public" was not in the path.  In hyrax it works with this check.  When this goes to testing, need to check that the logo and banner show up for the collection page.  There may be some file configuration to the path that may need tweaking. 


