### PR TITLE
more filtering on stats

### DIFF
--- a/app/services/deepblue/analytics_integration_service.rb
+++ b/app/services/deepblue/analytics_integration_service.rb
@@ -21,6 +21,7 @@ module Deepblue
     mattr_accessor :event_tracking_include_request_uri, default: false
     mattr_accessor :hit_graph_day_window, default: 30 # set to < 1 for no limit
     mattr_accessor :hit_graph_view_level, default: 0 # 0 = none, 1 = admin, 2 = editor, 3 = everyone
+    mattr_accessor :max_visit_filter_count, default: 50
     mattr_accessor :monthly_analytics_report_subscription_id, default: 'MonthlyAnalyticsReport'
     mattr_accessor :monthly_events_report_subscription_id, default: 'MonthlyEventsReport'
 

--- a/config/initializers/analytics_integration.rb
+++ b/config/initializers/analytics_integration.rb
@@ -23,6 +23,7 @@ Deepblue::AnalyticsIntegrationService.setup do |config|
   end
   config.hit_graph_day_window = 30 # set to < 1 for no limit
 
+  config.max_visit_filter_count = 50
   config.monthly_analytics_report_subscription_id = 'MonthlyAnalyticsReport'
   config.monthly_events_report_subscription_id = 'MonthlyEventsReport'
 

--- a/spec/services/deepblue/analytics_integration_service_spec.rb
+++ b/spec/services/deepblue/analytics_integration_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe ::Deepblue::AnalyticsIntegrationService do
       expect( ::Deepblue::AnalyticsIntegrationService.event_tracking_include_request_uri ).to eq( false )
       expect( ::Deepblue::AnalyticsIntegrationService.hit_graph_day_window               ).to eq( 30 )
       expect( ::Deepblue::AnalyticsIntegrationService.hit_graph_view_level               ).to eq( 2 )
+      expect( ::Deepblue::AnalyticsIntegrationService.max_visit_filter_count             ).to eq( 50 )
       expect( ::Deepblue::AnalyticsIntegrationService.monthly_analytics_report_subscription_id ).to eq( 'MonthlyAnalyticsReport' )
       expect( ::Deepblue::AnalyticsIntegrationService.monthly_events_report_subscription_id ).to eq( 'MonthlyEventsReport' )
     end


### PR DESCRIPTION
This is for issue:  https://tools.lib.umich.edu/jira/browse/BLUEDOC-1290

In looking at this, it seems like a good and simple solution is to filter out the events for which there are more than 50 Events with the same visit_id.  The visit_id is a key to the Ahoy::Visit table.  From speaking to Fritz, he is under the impression that the visits_ids are reset after 4 hours.  From looking that the table, it looks like there is a one-to-one correspondence between the visit_id and ip, so for now, we may be able to get away from having to count the actual ip visits, but rely on the visit_id as an indicator of ips that keep making the same request.

Since the Ahoy gem, according to the documentation, takes care of known crawlers, for now we will not check ips to see if they are crawlers.  With the additional check done in this PR, it may be enough.