### PR TITLE
remove more/less from author list.

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -51,7 +51,7 @@
         <% authors = raw (presenter.attribute_to_html(:creator, render_as: :faceted, label: t('show.labels.creator') ).gsub!('itemscope itemtype="http://schema.org/Person"', '').gsub!('<td>', '').gsub!('</td>', '').gsub!('<tr>', '').gsub!('</tr>', '').gsub!(/<th.*?>(.+?)<\/th>/, '').gsub!(/<ul.*?>(.+?)<\/ul>/, '\1').gsub!(/<li.*?>(.+?)<\/li>/, '\1|  ').gsub!(/<span.*?>(.+?)<\/span>/, '\1')) %>
         <% authors = authors.reverse.sub('|', '').sub('|', ' dna ').reverse.gsub!('|', ';') %>
 
-        <%= raw ("<span class=\"more\">") + authors + raw("</span>" ) %>
+        <%= raw ( authors ) %>
 
       </li>
     </ul>


### PR DESCRIPTION
When there are more than 5 authors, in the work page, list them in paragraph form, do not implement more/less for now.  Because there are "<a" tags associated with the author list, the more/less that we have does not work.  For now, after talking to Rachel, we decided to wait on this.  

For reference, in the description, which uses more/less there is a function that changes the "tags" to text, and if you do this the more/less works, but then you loose the link.  Here is a snippet of that code:

<%= raw ("<span class=\"more\">" + iconify_auto_link(description) + "</span>") %>

The iconify_auto_link is what converts the tags to text.