### PR TITLE
make a job to reset condensed table

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -165,6 +165,7 @@ END_OF_MONTHLY_EVENTS_REPORT_EMAIL_TEMPLATE
     events.each do |e|
       v = Ahoy::Visit.where( id: e.visit_id )
       count += 1 if v.first.ip.eql?(visit_to_test.first.ip)
+      break if count > max_visit_filter_count
     end
     count
   end

--- a/app/jobs/reset_condensed_events_job.rb
+++ b/app/jobs/reset_condensed_events_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class ResetCondensedEventsJob < ::Deepblue::DeepblueJob
+
+  mattr_accessor :reset_condensed_events_job_debug_verbose,
+                 default: ::Deepblue::JobTaskHelper.reset_condensed_events_job_debug_verbose
+
+SCHEDULER_ENTRY = <<-END_OF_SCHEDULER_ENTRY
+
+update_condensed_events_job:
+  # Run once a day, twenty-five minutes after midnight (which is offset by 4 or [5 during daylight savings time], due to GMT)
+  #      M H D
+  # cron: '*/5 * * * *'
+  cron: '25 5 * * *'
+  class: ResetCondensedEventsJob
+  queue: scheduler
+  description: Reset the condensed events job.
+  args:
+    hostnames:
+      - 'deepblue.lib.umich.edu'
+      - 'staging.deepblue.lib.umich.edu'
+      - 'testing.deepblue.lib.umich.edu'
+    quiet: true
+    by_request_only: true
+    subscription_service_id: reset_condensed_events_job         
+
+END_OF_SCHEDULER_ENTRY
+
+  queue_as :scheduler
+
+  def perform( *args )
+    job_msg_queue << "Start processing at #{DateTime.now}"    
+    ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
+                                           ::Deepblue::LoggingHelper.called_from,
+                                           "args=#{args}",
+                                           "" ] if reset_condensed_events_job_debug_verbose
+    initialize_options_from( *args, debug_verbose: reset_condensed_events_job_debug_verbose )
+    return job_finished unless hostname_allowed?
+    log( event: "reset condensed events job", hostname_allowed: hostname_allowed? )
+    is_quiet?
+    ::AnalyticsHelper.drop_condensed_event_downloads
+    job_msg_queue << "Done dropping condensed events at #{DateTime.now}" 
+    ::AnalyticsHelper.initialize_condensed_event_downloads
+    job_msg_queue << "Done initializing condensed events at #{DateTime.now}"
+
+    job_finished
+    job_msg_queue << "Finished processing at #{DateTime.now}"
+    email_results
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    job_status_register( exception: e, args: args )
+    email_failure( task_name: self.class.name, exception: e, event: self.class.name )
+    raise
+  end
+  
+end


### PR DESCRIPTION
This is a very straight forward Job.  Here are some things to keep in mind:

(1)  by_request_only: true  ==> This means the Job will not run on schedule but when the user hits "Run" on the Manage Jobs page.

(2)  subscription_service_id: reset_condensed_events_job  ==>  this will enable users to subscribe to the job, and by doing so receive an email when the job completes.

(3) job_msg_queue << "Start processing at #{DateTime.now}"   ==> This is the text of the message that gets emailed.

(4)  email_results  ==> This is the line that sends out the email.


