### PR TITLE
put work in workflow

### DIFF
--- a/app/services/hyrax/default_middleware_stack.rb
+++ b/app/services/hyrax/default_middleware_stack.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+module Hyrax
+  class DefaultMiddlewareStack
+    # rubocop:disable Metrics/MethodLength
+    def self.build_stack
+      ActionDispatch::MiddlewareStack.new.tap do |middleware|
+        # Ensure you are mutating the most recent version
+        middleware.use Hyrax::Actors::OptimisticLockValidator
+
+        # Attach files from a URI (for BrowseEverything)
+        middleware.use Hyrax::Actors::CreateWithRemoteFilesActor
+
+        # Attach files uploaded in the form to the UploadsController
+        middleware.use Hyrax::Actors::CreateWithFilesActor
+
+        # Add/remove the resource to/from a collection
+        middleware.use Hyrax::Actors::CollectionsMembershipActor
+
+        # Add/remove to parent work
+        middleware.use Hyrax::Actors::AddToWorkActor
+
+        # Add/remove children (works or file_sets)
+        middleware.use Hyrax::Actors::AttachMembersActor
+
+        # Set the order of the children (works or file_sets)
+        middleware.use Hyrax::Actors::ApplyOrderActor
+
+        # Sets the default admin set if they didn't supply one
+        middleware.use Hyrax::Actors::DefaultAdminSetActor
+
+        # Decode the private/public/institution on the form into permisisons on
+        # the model
+        middleware.use Hyrax::Actors::InterpretVisibilityActor
+
+        # Copies default permissions from the PermissionTemplate to the work
+        middleware.use Hyrax::Actors::ApplyPermissionTemplateActor
+
+        # Remove attached FileSets when destroying a work
+        middleware.use Hyrax::Actors::CleanupFileSetsActor
+
+        # Destroys the trophies in the database when the work is destroyed
+        middleware.use Hyrax::Actors::CleanupTrophiesActor
+
+        # Destroys the feature tag in the database when the work is destroyed
+        middleware.use Hyrax::Actors::FeaturedWorkActor
+
+        # Persist the metadata changes on the resource
+        middleware.use Hyrax::Actors::ModelActor
+
+        # Start the workflow for this work
+        middleware.use Hyrax::Actors::InitializeWorkflowActor
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/spec/actors/hyrax/actors/data_set_actor_spec.rb
+++ b/spec/actors/hyrax/actors/data_set_actor_spec.rb
@@ -219,6 +219,9 @@ RSpec.describe Hyrax::Actors::DataSetActor do
 
   describe '#update' do
     let(:curation_concern) { create(:data_set, user: user, admin_set_id: admin_set.id) }
+    before do
+      allow(curation_concern).to receive(:to_sipity_entity).and_return(nil)
+    end
 
     context 'failure' do
       let(:attributes) { {} }


### PR DESCRIPTION
Fixes:  https://mlit.atlassian.net/browse/DEEPBLUE-52


I brought this file over from hyrax 3 because it was missing the last actor:

        # Start the workflow for this work
        middleware.use Hyrax::Actors::InitializeWorkflowActor

Strangely, this was in the 2.9 version.  Not sure what happened.  I suspect this is a bug in Hyrax 3.

Without this actor, he work would be created, but it would not be put in the workflow, so you did not see the blue "Pending review" badge, and when you opened the "Review Approval" area, the options with the radio buttons were missing. 

As a reminder, the actors are in the dir: app/actors/hyrax/actors

Remember that the actors have the CRUD methods in them.
