### PR TITLE
logo record processing checks for string, not just public dir

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -187,7 +187,11 @@ module Hyrax
       def process_logo_records(uploaded_file_ids)
         public_files = []
         uploaded_file_ids.each_with_index do |ufi, i|
-          if ufi.include?('public')
+          # If user has chosen a new logo, the ufi will be an integer
+          # If the logo was previously chosen, the ufil will be a path
+          # ufi.match(/\D/) will return a nil, fi ufi is an integer
+          # if it is a path, you want to update the, else create a new rec
+          if ! ufi.match(/\D/).nil?
             update_logo_info(ufi, params["alttext"][i], verify_linkurl(params["linkurl"][i]))
             public_files << ufi
           else # brand new one, insert in the database


### PR DESCRIPTION
Fixes: https://mlit.atlassian.net/browse/DEEPBLUE-65

This was a fix that I worked for Hyrax, it did not make it in v3, but it is important.