### PR TITLE
allow work to be placed in correct admin set when using sword.

### DIFF
--- a/app/actors/hyrax/actors/default_admin_set_actor.rb
+++ b/app/actors/hyrax/actors/default_admin_set_actor.rb
@@ -69,8 +69,9 @@ module Hyrax
                                                    "admin_set=#{admin_set}",
                                                    "admin_set.title=#{admin_set&.title}",
                                                    "" ] if default_admin_set_actor_debug_verbose
-            unless admin_set.id.eql? Rails.configuration.default_admin_set_id &&
-                                       admin_set&.title&.first == Rails.configuration.data_set_admin_set_title
+                                                   byebug
+            unless ( (admin_set.id.eql? Rails.configuration.default_admin_set_id) &&
+                                       (admin_set&.title&.first != Rails.configuration.data_set_admin_set_title) )
               ::Deepblue::LoggingHelper.bold_debug [ ::Deepblue::LoggingHelper.here,
                                                      ::Deepblue::LoggingHelper.called_from,
                                                      "assigning admin set id=#{admin_set.id}",


### PR DESCRIPTION
This is to address this issue:  https://mlit.atlassian.net/browse/DEEPBLUE-70

This PR will allow sword deposits to be place in the correct admin set, and in turn be put in the workflow.

Here are something to remember when debugging this issue on my local machine:

(1) Go to this dir:  /Users/blancoj/work/sword_work

(2) In order not to bother with the Kye set this to false:

config/initializers/willow_sword.rb
  config.authorize_request = false

(3)  You can then issue this command from the dir I indicated in (1)

curl --request POST --url http://localhost:3000/data/sword/collections/cj82k729x/works \
--header 'Content-Disposition: attachment; filename=metadata.xml' \
--header 'Content-Type: application/xml' \
--header 'In-Progress: false' \
--header 'Packaging: application/atom+xml;type=entry' \
--data-binary @dc.xml


