### PR TITLE
allow works to be tombstoned in version 3 of hyrax.

### DIFF
--- a/app/indexers/data_set_indexer.rb
+++ b/app/indexers/data_set_indexer.rb
@@ -37,7 +37,7 @@ class DataSetIndexer < Hyrax::WorkIndexer
       # So that title sort can be done ...
       solr_doc['title_sort_ssi'] = Array(object.title).first.downcase unless object.title.blank?
 
-      solr_doc[:tombstone_tesim] = object.tombstone
+      solr_doc[:tombstone_ssim] = object.tombstone
       # solr_doc[Solrizer.solr_name('total_file_size', Hyrax::FileSetIndexer::STORED_LONG)] = object.total_file_size
       solr_doc[:total_file_size_lts] = object.size_of_work
 

--- a/app/models/data_set.rb
+++ b/app/models/data_set.rb
@@ -546,7 +546,14 @@ class DataSet < ActiveFedora::Base
     depositor_at_tombstone = depositor
     visibility_at_tombstone = visibility
     self.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-    self.state = Vocab::FedoraResourceStatus.inactive
+
+    # The state indicates if an object is Published or not.
+    # Tombstone objects are Published first and then Tombstoned.
+    # If you set the state to inactive, you will not be able to Filter for Restricted, Published works,
+    # in the works dashboard and find the Tombstoned works.
+    # To find them, you would have to search for Restricted, Under Review works, which 
+    # does not reflect the works true status/state.
+    #self.state = Vocab::FedoraResourceStatus.inactive
     self.depositor = depositor
     self.tombstone = [epitaph]
 


### PR DESCRIPTION
Fixes:  https://mlit.atlassian.net/browse/DEEPBLUE-81

Two things to keep in mind from this PR:
(1) With version 3 of Hyrax, this was brought in:
  solr_doc[:tombstone_tesim] = object.tombstone
But prior to this version, we used:
      solr_doc[:tombstone_ssim] = object.tombstone

So I reverted back to using tombstone_ssim.

(2) This old PR: https://github.com/mlibrary/deepblue/pull/1016  made a change to the entomb! method to do this:
self.state = Vocab::FedoraResourceStatus.inactive

What this does is change the Status of the work from Published to Under review, so if you Filter for it on the dashboard you will find it in the Under review status, when the work was actually published.  In order to find the works that are tombstoned, you sort on the dashboard as Visibility > Restricted and Status > Published.  In production, you can verify this.  I noticed that all the items that have been tombstoned in production and were showing up were before PR 1016 was released. So nothing has been tombstoned after the release of PR 1016, so it is safe to say that PR 1016 did not affect any works.




