### PR TITLE
add citation to related materials to show in work page.

### DIFF
--- a/app/models/concerns/umrdr/umrdr_work_metadata.rb
+++ b/app/models/concerns/umrdr/umrdr_work_metadata.rb
@@ -88,11 +88,10 @@ module Umrdr
         index.as :stored_searchable
       end
 
-      # already defined property in hyrax v3
-      # property :referenced_by, predicate: ::RDF::Vocab::DC.isReferencedBy, multiple: true do |index|
-      #   index.type :text
-      #   index.as :stored_searchable
-      # end
+      property :referenced_by, predicate: ::RDF::Vocab::DC.isReferencedBy, multiple: true do |index|
+         index.type :text
+         index.as :stored_searchable
+      end
 
       property :referenced_by_ordered, predicate: ::RDF::URI.new('https://deepblue.lib.umich.edu/data/help.help#referenced_by_ordered'), multiple: false do |index|
         index.type :text


### PR DESCRIPTION
Fixes: https://mlit.atlassian.net/browse/DEEPBLUE-86

This was a good PR to look at showing a metadata added to the system:
https://github.com/mlibrary/deepblue/pull/102/files

Solr may need to be reindexed.  I had an item that had did had this metadata field, and after I made this change, the metadata was not showing in the work page, but after I saved it again, it showed up.  