### PR TITLE
allow works in draft mode to be deleted and files by depositor.

### DIFF
--- a/app/presenters/hyrax/ds_file_set_presenter.rb
+++ b/app/presenters/hyrax/ds_file_set_presenter.rb
@@ -268,10 +268,13 @@ module Hyrax
                                              "true editor?=#{editor?}",
                                              "and pending_publication?=#{pending_publication?}",
                                              "" ] if ds_file_set_presenter_debug_verbose
+
       return false if anonymous_show?
       return false if parent.tombstone.present?
       return true if current_ability.admin?
+      return false if parent.doi.present?
       return true if editor? && pending_publication?
+      return true if current_ability.current_user.email.present? && current_ability.current_user.email.to_s == depositor
       false
     end
 

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -252,6 +252,8 @@ module Hyrax
       return false if doi_minted?
       return false if tombstoned?
       return true if current_ability.admin?
+      # can delete if in draft mode and the current user is the depositor.
+      return true if draft_mode? && (current_ability.current_user.email.present? && current_ability.current_user.email.to_s == depositor)
       return false if draft_mode?
       can_edit_work?
     end

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -17,34 +17,34 @@
       <li>
         <%= link_to t('.view_details'), member.show_path_link( main_app: main_app ), method: :get %>
       </li>
-      <%# if can?(:edit, member.id) %>
-        <% unless @presenter.doi_minted? && !current_ability.admin? %>
-          <li role="menuitem" tabindex="-1">
-            <%= link_to t('.edit'),
-                        edit_polymorphic_path([main_app, member]),
-                        { title: t('.edit_title', file_set: member) } %>
-          </li>
-        <% end %>
-        <% if member.can_assign_to_work_as_read_me? %>
-          <li role="menuitem" tabindex="-1">
-            <%= link_to t('.assign_read_me'),
-                        main_app.assign_to_work_as_read_me_hyrax_file_set_path( member.id ),
-                        { title: t('.assign_read_me_title') } %>
-          </li>
-        <% end %>
-        <% if member.can_display_file_contents? %>
-          <li role="menuitem" tabindex="-1">
-            <%= link_to t('.contents'),
-                        main_app.file_contents_hyrax_file_set_path( member.id ),
-                        { title: t('.contents_title') } %>
-          </li>
-        <% end %>
+      <% unless @presenter.doi_minted? && !current_ability.admin? %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.edit'),
+                      edit_polymorphic_path([main_app, member]),
+                      { title: t('.edit_title', file_set: member) } %>
+        </li>
+      <% end %>
+      <% if member.can_assign_to_work_as_read_me? %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.assign_read_me'),
+                      main_app.assign_to_work_as_read_me_hyrax_file_set_path( member.id ),
+                      { title: t('.assign_read_me_title') } %>
+        </li>
+      <% end %>
+      <% if member.can_display_file_contents? %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.contents'),
+                      main_app.file_contents_hyrax_file_set_path( member.id ),
+                      { title: t('.contents_title') } %>
+        </li>
+      <% end %>
+      <% unless @presenter.draft_mode?  %>
         <li role="menuitem" tabindex="-1">
           <%= link_to t('.versions'),
                       edit_polymorphic_path([main_app, member], anchor: 'versioning_display'),
                       { title: t('.versions_title') } %>
         </li>
-      <%# end %>
+      <% end %>
       <% if member.can_delete_file? %>
         <li role="menuitem" tabindex="-1">
           <%= link_to t('.delete'),

--- a/spec/presenters/hyrax/ds_file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/ds_file_set_presenter_spec.rb
@@ -1,4 +1,4 @@
-
+require 'rails_helper'
 require 'iiif_manifest'
 
 RSpec.describe Hyrax::DsFileSetPresenter do
@@ -206,6 +206,7 @@ RSpec.describe Hyrax::DsFileSetPresenter do
   describe "#can_edit_file?" do
     subject { presenter.can_edit_file? }
     let(:current_ability) { ability }
+    let( :current_user ) { double( "current_user" ) }
     let ( :workflow ) { double( "workflow" ) }
 
     context 'cannot when tombstone present' do
@@ -249,11 +250,9 @@ RSpec.describe Hyrax::DsFileSetPresenter do
     context 'cannot when editor and deposited' do
       before do
         allow( parent_presenter ).to receive( :tombstone ).and_return nil
+        allow( parent_presenter ).to receive( :doi ).and_return "dsf"
         allow( presenter ).to receive( :anonymous_show? ).and_return false
         allow( current_ability ).to receive( :admin? ).and_return false
-        expect( presenter ).to receive( :editor? ).at_least(:once).and_return true
-        expect( workflow ).to receive( :state ).at_least(:once).and_return "deposited"
-        expect( parent_presenter ).to receive( :workflow ).at_least(:once).and_return workflow
       end
       it { is_expected.to be false }
     end
@@ -264,6 +263,8 @@ RSpec.describe Hyrax::DsFileSetPresenter do
         allow( current_ability ).to receive( :admin? ).and_return false
         allow( presenter ).to receive( :editor? ).and_return false
         allow( workflow ).to receive( :state ).and_return "pending_review"
+        allow( current_user ).to receive( :email ).and_return nil
+        allow( current_ability ).to receive( :current_user ).and_return current_user
         allow( parent_presenter ).to receive( :workflow ).and_return workflow
       end
       it { is_expected.to be false }


### PR DESCRIPTION
This fixes: https://mlit.atlassian.net/browse/DEEPBLUE-117

This will need further testing on testing.  The idea is to allow depositors to be able to delete their work and the files attached to that work while the work is in draft mode.
