### PR TITLE
if user is non admin, the dashboard/collections page should show only…

### DIFF
--- a/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
+++ b/app/controllers/concerns/hyrax/breadcrumbs_for_collections.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Hyrax
+  module BreadcrumbsForCollections
+    extend ActiveSupport::Concern
+    include Hyrax::Breadcrumbs
+
+    included do
+      before_action :build_breadcrumbs, only: [:edit, :show]
+    end
+
+    def add_breadcrumb_for_controller
+      add_breadcrumb I18n.t('hyrax.dashboard.my.collections'), hyrax.my_collections_path if current_ability.admin?
+      add_breadcrumb I18n.t('hyrax.dashboard.my.collections'), hyrax.dashboard_collections_path unless current_ability.admin?
+    end
+
+    def add_breadcrumb_for_action
+      case action_name
+      when 'edit'
+        add_breadcrumb I18n.t("hyrax.collection.edit_view"), collection_path(params["id"]), mark_active_action
+      when 'show'
+        add_breadcrumb presenter.to_s, polymorphic_path(presenter), mark_active_action
+      end
+    end
+
+    def mark_active_action
+      { "aria-current" => "page" }
+    end
+  end
+end

--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -187,7 +187,8 @@ module Hyrax
       def index
         add_breadcrumb t(:'hyrax.controls.home'), root_path
         add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
-        add_breadcrumb t(:'hyrax.admin.sidebar.collections'), hyrax.my_collections_path
+        add_breadcrumb t(:'hyrax.admin.sidebar.collections'), hyrax.my_collections_path if current_ability.admin?
+        add_breadcrumb t(:'hyrax.admin.sidebar.collections'), hyrax.dashboard_collections_path unless current_ability.admin? 
         collection_type_list_presenter
         managed_collections_count
         super

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -32,8 +32,13 @@
       <% end %>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li><%= link_to t('hyrax.toolbar.dashboard.menu'), hyrax.dashboard_path %></li>
-        <li class="dropdown-menu-indent"><%= link_to t('hyrax.admin.sidebar.collections'),
-                                                     hyrax.my_collections_path %></li>
+        <% if current_ability.admin? %> 
+          <li class="dropdown-menu-indent"><%= link_to t('hyrax.admin.sidebar.collections'),
+                                                       hyrax.my_collections_path %></li>
+        <% else %>
+          <li class="dropdown-menu-indent"><%= link_to t('hyrax.admin.sidebar.collections'),
+                                                       hyrax.dashboard_collections_path %></li>
+        <% end %>
         <li class="dropdown-menu-indent"><%= link_to t('hyrax.admin.sidebar.works'),
                                                      hyrax.my_works_path %></li>
         <% if can? :review, :submissions %>

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -1,9 +1,16 @@
   <li class="h5"><%= t('hyrax.admin.sidebar.repository_objects') %></li>
 
+<% if current_ability.admin? %> 
   <%= menu.nav_link(hyrax.my_collections_path,
                     also_active_for: hyrax.dashboard_collections_path) do %>
     <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
   <% end %>
+<% else %>
+  <%= menu.nav_link(hyrax.dashboard_collections_path,
+                    also_active_for: hyrax.dashboard_collections_path) do %>
+    <span class="fa fa-folder-open" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.collections') %></span>
+  <% end %>
+<% end %>
 
   <%= menu.nav_link(hyrax.my_works_path,
                     also_active_for: hyrax.dashboard_works_path) do %>

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true, skip: false do
       it "returns the collection and its members" do # rubocop:disable RSpec/ExampleLength
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :show, params: { id: collection }
         expect(response).to be_successful
@@ -110,7 +110,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true, skip: false do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
@@ -125,7 +125,7 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true, skip: false do
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo, skip: false
       it "returns the collection and its members" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :show, params: { id: collection }
         expect(response).to be_successful
@@ -416,7 +416,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo, skip: false
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
@@ -431,7 +431,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo, skip: false
         it "sets breadcrumbs" do
           expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
           expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), "aria-current" => "page")
           get :show, params: { id: collection }
           expect(response).to be_successful
@@ -520,7 +520,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo, skip: false
       it "sets breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :edit, params: { id: collection }
         expect(response).to be_successful
@@ -537,7 +537,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo, skip: false
       it "sets breadcrumbs" do
         expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.dashboard_collections_path(locale: 'en'))
         expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), "aria-current" => "page")
         get :edit, params: { id: collection }
         expect(response).to be_successful

--- a/spec/controllers/hyrax/my/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/my/collections_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Hyrax::My::CollectionsController, type: :controller, skip: false 
 
   describe "logged in user" do
     describe "#index" do
-      let(:user) { create(:user) }
+      let(:user) { create(:admin) }
+      let(:ability) { Ability.new(user) }
       let(:response) { instance_double(Blacklight::Solr::Response, response: { 'numFound' => 3 }) }
       let(:doc_list) { [double(id: 123), double(id: 456)] }
 

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -2,12 +2,16 @@ require 'rails_helper'
 
 RSpec.describe '/_user_util_links.html.erb', type: :view do
   let(:join_date) { 5.days.ago }
+  let(:ability) { double "Ability" }
 
   context "standard depositor" do
 
     before do
+      allow(ability).to receive(:admin?).and_return true
+      allow(view).to receive(:current_ability).and_return(ability)
       allow(view).to receive(:user_signed_in?).and_return true
       allow(view).to receive(:current_user).and_return stub_model(User, user_key: 'userX')
+      allow(view).to receive(:current_ability).with(:admin?).and_return true
       allow(view).to receive(:can?).with(:create, DataSet).and_return true
       allow(view).to receive(:can?).with(:manage, User).and_return false
       allow(view).to receive(:can?).with(:review, :submissions).and_return false
@@ -76,6 +80,8 @@ RSpec.describe '/_user_util_links.html.erb', type: :view do
   context "admin" do
 
     before do
+      allow(ability).to receive(:admin?).and_return true
+      allow(view).to receive(:current_ability).and_return(ability)
       allow(view).to receive(:user_signed_in?).and_return true
       allow(view).to receive(:current_user).and_return stub_model(User, user_key: 'userX')
       allow(view).to receive(:can?).with(:create, DataSet).and_return true

--- a/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/_sidebar.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
   let(:user) { stub_model(User, user_key: 'mjg', name: 'Foobar') }
+  let(:ability) { double "Ability" }
   let(:read_admin_dashboard) { false }
   let(:manage_any_admin_set) { false }
   let(:review_submissions) { false }
@@ -12,6 +13,8 @@ RSpec.describe 'hyrax/dashboard/_sidebar.html.erb', type: :view do
   let(:manage_collection_types) { false }
 
   before do
+    allow(ability).to receive(:admin?).and_return false
+    allow(view).to receive(:current_ability).and_return(ability)
     allow(view).to receive(:signed_in?).and_return(true)
     allow(view).to receive(:current_user).and_return(user)
     assign(:user, user)


### PR DESCRIPTION
… managed collections.

Fixes: https://mlit.atlassian.net/browse/DEEPBLUE-177

Things to keep in mind:
(1) You can toggle between being admin or not in this `admin?` method, by returning true or false.  The code is in this file:

app/models/concerns/hyrax/ability.rb

(2) The issue here was that at one point users could create collections, but this was changed so that only admins can create collections.  This made the Collections page from the Dashboard confusing since in this page you list the collections a user owns (he/she created), and there was also a link to the collections the user manages on this page if the user was not admin.  It was decided that it was best to make all users that owned collections lose their ownership and give that ownership to Rachel.  Then, in the dashboard Collections page, if you are not admin, you list the collections you manage; if you are admin, you list the ones you own.

(3) To determine who owned the collections, this was run from `rails console` in production:
colls = Collection.all
colls.each do |c|
puts c.title.first + "====>" + c.depositor
end

(4) Rachel then went to the the UI and made all users that owned the collections managers to the the collections.

(5) Then, this bit of code made Rachel owner of the collections, where the collections were not owned by an admin:

Collection.all.each do |c|
  next if ::Ability.new(User.find_by_user_key( c.depositor )).admin? 
  c.depositor = "woodbr@umich.edu"
  c.save!(validate: false)
end;true

(6)  The paths to `manage collections` and `owned collections.`

to see owned collections ==> dashboard/my/collections?locale=en       (if admin)
to see the managed collections ==> dashboard/collections?locale=en  (if not admin)

(7)  So basically the code change that was made was to put the appropriate path on the sidebar and the breadcrumb.  I did not change the breadcrumb for the Admin page, since only admins can get there.





