### PR TITLE
changes to the MCommunity API Jan 2023

### DIFF
--- a/app/helpers/mcommunity_helper.rb
+++ b/app/helpers/mcommunity_helper.rb
@@ -18,7 +18,6 @@ module McommunityHelper
     request["Accept"] = "application/json"
     request["Authorization"] = "Bearer " + token
     request["x-ibm-client-id"] = Settings.mcommunity.client_id
-    request["Cookie"] = Settings.mcommunity.cookie
 
     response = https.request(request)
 
@@ -26,8 +25,8 @@ module McommunityHelper
     return JSON.parse(value)
   end
 
-	def self.get_token
-    url = URI("#{Settings.mcommunity.url}inst/oauth2/token?grant_type=client_credentials&scope=mcommunity")
+  def self.get_token
+    url = URI("#{Settings.mcommunity.url}oauth2/token?grant_type=client_credentials&scope=mcommunity")
 
     https = Net::HTTP.new(url.host, url.port)
     https.use_ssl = true
@@ -36,13 +35,12 @@ module McommunityHelper
     request["Accept"] = "application/json"
     request["Authorization"] = "Basic " + Settings.mcommunity.authorization
     request["x-ibm-client-id"] = Settings.mcommunity.client_id
-    request["Cookie"] = Settings.mcommunity.cookie
 
     response = https.request(request)
     value = response.read_body
     obj = JSON.parse(value)
     return obj['access_token']
-	end
+  end
 
   def self.get_orchid( email )
     unique_id = email.split('@')[0].strip


### PR DESCRIPTION
Fixes:  https://mlit.atlassian.net/browse/DEEPBLUE-188

We are no longer using a cookie. 

The authorization number was computed using this site:  https://www.base64encode.org/

Basically you put the clien_id:secrete_key ( in this format with the colon ) and hit "ENCODE" to get the base64 number you use in the for authorization.

To see the orcid display, go to dashboard from the login menu.
